### PR TITLE
Downgrade typehint for group rules in Validator

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -16,7 +16,7 @@ class Validator
      * Validator constructor.
      * @param $rules
      */
-    public function __construct(array $rules = [])
+    public function __construct(iterable $rules = [])
     {
         foreach ($rules as $attribute => $ruleSets) {
             foreach ($ruleSets as $rule) {


### PR DESCRIPTION
Iterable hint will make it possible to use objects, that implements ArrayAccess interface

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  |
