### PR TITLE
Fix Typed property Validator::$attributeRules must not be accessed be…

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -13,7 +13,7 @@ class Validator
     /**
      * @var Rules[]
      */
-    private array $attributeRules;
+    private array $attributeRules = [];
 
     /**
      * Validator constructor.


### PR DESCRIPTION
Typed property `Yiisoft\\Validator\\Validator::$attributeRules` must not be accessed before initialization

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  |
