### PR TITLE
Use iterable instead of two subtypes.

### DIFF
--- a/src/Rule/InRange.php
+++ b/src/Rule/InRange.php
@@ -10,6 +10,8 @@ use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Validator\Result;
 use Yiisoft\Validator\DataSetInterface;
 
+use function is_iterable;
+
 /**
  * In validates that the attribute value is among a list of values.
  *
@@ -23,9 +25,9 @@ class InRange extends Rule
     use HasValidationMessage;
 
     /**
-     * @var array|\Traversable
+     * @var iterable
      */
-    private $range;
+    private iterable $range;
     /**
      * @var bool whether the comparison is strict (both type and value must be the same)
      */
@@ -38,12 +40,8 @@ class InRange extends Rule
 
     private string $message = 'This value is invalid.';
 
-    public function __construct($range)
+    public function __construct(iterable $range)
     {
-        if (!is_array($range) && !($range instanceof \Traversable)) {
-            throw new \RuntimeException('The "range" property must be set.');
-        }
-
         $this->range = $range;
     }
 
@@ -52,7 +50,7 @@ class InRange extends Rule
         $in = false;
 
         if (
-            ($value instanceof \Traversable || is_array($value)) &&
+            (is_iterable($value)) &&
             ArrayHelper::isSubset($value, $this->range, $this->strict)
         ) {
             $in = true;

--- a/tests/Rule/InRangeTest.php
+++ b/tests/Rule/InRangeTest.php
@@ -10,13 +10,6 @@ use Yiisoft\Validator\Rule\InRange;
  */
 class InRangeTest extends TestCase
 {
-    public function testInitException(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The "range" property must be set.');
-        new InRange('not an array');
-    }
-
     public function testValidate(): void
     {
         $val = new InRange(range(1, 10));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Use `iterable` type (introduced in PHP 7.1) instead of two subtypes (`array` and `\Traversable`). This simplifies the code and allows correct type-hinting without init validation.
