### PR TITLE
Rules provider

### DIFF
--- a/src/PostValidationHookInterface.php
+++ b/src/PostValidationHookInterface.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Yiisoft\Validator;
 
 /**
- * Allows to make validation post-processing.
+ * Allows to implement post-validation processing in the data set object itself.
  *
- * @example {@see \Yiisoft\Form\FormModel::processValidationResult}
+ * @see \Yiisoft\Form\FormModel::processValidationResult
  */
 interface PostValidationHookInterface extends DataSetInterface
 {

--- a/src/PostValidationHookInterface.php
+++ b/src/PostValidationHookInterface.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Validator;
 
 /**
  * Allow to make validation post-processing.
+ *
  * @example {@see \Yiisoft\Form\FormModel::processValidationResult}
  */
 interface PostValidationHookInterface extends DataSetInterface

--- a/src/PostValidationHookInterface.php
+++ b/src/PostValidationHookInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator;
+
+/**
+ * Allow to make validation post-processing.
+ * @example {@see \Yiisoft\Form\FormModel::processValidationResult}
+ */
+interface PostValidationHookInterface extends DataSetInterface
+{
+    public function processValidationResult(ResultSet $resultSet): void;
+}

--- a/src/PostValidationHookInterface.php
+++ b/src/PostValidationHookInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator;
 
 /**
- * Allow to make validation post-processing.
+ * Allows to make validation post-processing.
  *
  * @example {@see \Yiisoft\Form\FormModel::processValidationResult}
  */

--- a/src/RulesProviderInterface.php
+++ b/src/RulesProviderInterface.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Yiisoft\Validator;
 
 /**
- * Allows pass only one argument to the {@see ValidatorInterface}.
+ * Allows to have data validation rules together with the data itself.
+ * Such object can be passed as an only argument to the {@see ValidatorInterface}.
  */
 interface RulesProviderInterface extends DataSetInterface
 {
+    /**
+     * @return iterable A set of validation rules.
+     */
     public function getRules(): iterable;
 }

--- a/src/RulesProviderInterface.php
+++ b/src/RulesProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator;
+
+/**
+ * Allows pass only one argument to the {@see ValidatorInterface}.
+ */
+interface RulesProviderInterface extends DataSetInterface
+{
+    public function getRules(): iterable;
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -17,14 +17,18 @@ final class Validator implements ValidatorInterface
     }
 
     /**
-     * @param DataSetInterface $dataSet
+     * @param DataSetInterface|RulesProviderInterface $dataSet
      * @param Rule[][] $rules
      * @psalm-param iterable<string, Rule[]> $rules
      *
      * @return ResultSet
      */
-    public function validate(DataSetInterface $dataSet, iterable $rules): ResultSet
+    public function validate(DataSetInterface $dataSet, iterable $rules = []): ResultSet
     {
+        if ($dataSet instanceof RulesProviderInterface) {
+            /** @noinspection CallableParameterUseCaseInTypeContextInspection */
+            $rules = $dataSet->getRules();
+        }
         $context = new ValidationContext($dataSet);
         $results = new ResultSet();
         foreach ($rules as $attribute => $attributeRules) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -30,18 +30,21 @@ final class Validator implements ValidatorInterface
             $rules = $dataSet->getRules();
         }
         $context = new ValidationContext($dataSet);
-        $results = new ResultSet();
+        $resultSet = new ResultSet();
         foreach ($rules as $attribute => $attributeRules) {
             $aggregateRule = new Rules($attributeRules);
             if ($this->formatter !== null) {
                 $aggregateRule = $aggregateRule->withFormatter($this->formatter);
             }
-            $results->addResult(
+            $resultSet->addResult(
                 $attribute,
                 $aggregateRule->validate($dataSet->getAttributeValue($attribute), $context->withAttribute($attribute))
             );
         }
-        return $results;
+        if ($dataSet instanceof PostValidationHookInterface) {
+            $dataSet->processValidationResult($resultSet);
+        }
+        return $resultSet;
     }
 
     public function withFormatter(?FormatterInterface $formatter): self

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -12,11 +12,11 @@ interface ValidatorInterface
     /**
      * Validate data set against rules set for data set attributes.
      *
-     * @param DataSetInterface $dataSet Data set to validate.
+     * @param DataSetInterface|RulesProviderInterface $dataSet Data set to validate.
      * @param Rule[][] $rules Rules to apply.
      * @psalm-param iterable<string, Rule[]> $rules
      *
      * @return ResultSet Validation results.
      */
-    public function validate(DataSetInterface $dataSet, iterable $rules): ResultSet;
+    public function validate(DataSetInterface $dataSet, iterable $rules = []): ResultSet;
 }

--- a/tests/AbstractDataSetTest.php
+++ b/tests/AbstractDataSetTest.php
@@ -6,53 +6,55 @@ namespace Yiisoft\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\ResultSet;
 use Yiisoft\Validator\Rule\Boolean;
 use Yiisoft\Validator\Rule\Number;
-use Yiisoft\Validator\Tests\Stub\DataSet;
-use Yiisoft\Validator\Tests\Stub\RulesProvidedDataSet;
-use Yiisoft\Validator\Validator;
 
-class ValidatorTest extends TestCase
+abstract class AbstractDataSetTest extends TestCase
 {
     /**
      * @dataProvider validationCasesDataProvider()
      * @param array $dataSet
      */
-    public function testAddingRulesViaConstructor(array $dataSet, array $rules): void
+    final public function test(array $dataSet, array $rules): void
     {
-        $dataObject = new DataSet($dataSet);
+        $resultSet = $this->validate($dataSet, $rules);
 
-        $validator = new Validator();
-
-        $results = $validator->validate($dataObject, $rules);
-
-        $this->assertTrue($results->getResult('bool')->isValid());
-
-        $intResult = $results->getResult('int');
-        $this->assertFalse($intResult->isValid());
-        $this->assertCount(1, $intResult->getErrors());
-    }
-
-    /**
-     * @dataProvider validationCasesDataProvider()
-     * @param array $dataSet
-     */
-    public function testRulesProvidedObject(array $dataSet, array $rules): void
-    {
-        $dataObject = new RulesProvidedDataSet($dataSet, $rules);
-
-        $validator = new Validator();
-
-        $results = $validator->validate($dataObject);
-
-        $this->assertTrue($results->getResult('bool')->isValid());
-
-        $intResult = $results->getResult('int');
-        $this->assertFalse($intResult->isValid());
-        $this->assertCount(1, $intResult->getErrors());
+        $this->assertTrue($resultSet->isValid());
     }
 
     public function validationCasesDataProvider(): array
+    {
+        return [
+            [
+                [
+                    'bool' => true,
+                    'int' => 41,
+                ],
+                [
+                    'bool' => [new Boolean()],
+                    'int' => [new Number()],
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider resultDataProvider()
+     * @param array $dataSet
+     */
+    public function testResult(array $dataSet, array $rules): void
+    {
+        $resultSet = $this->validate($dataSet, $rules);
+
+        $this->assertTrue($resultSet->getResult('bool')->isValid());
+
+        $intResult = $resultSet->getResult('int');
+        $this->assertFalse($intResult->isValid());
+        $this->assertCount(1, $intResult->getErrors());
+    }
+
+    public function resultDataProvider(): array
     {
         return [
             [
@@ -77,4 +79,6 @@ class ValidatorTest extends TestCase
             ]
         ];
     }
+
+    abstract protected function validate(array $dataSet, array $rules): ResultSet;
 }

--- a/tests/AbstractDataSetTest.php
+++ b/tests/AbstractDataSetTest.php
@@ -14,6 +14,7 @@ abstract class AbstractDataSetTest extends TestCase
 {
     /**
      * @dataProvider validationCasesDataProvider()
+     *
      * @param array $dataSet
      */
     final public function test(array $dataSet, array $rules): void
@@ -34,13 +35,14 @@ abstract class AbstractDataSetTest extends TestCase
                 [
                     'bool' => [new Boolean()],
                     'int' => [new Number()],
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
     /**
      * @dataProvider resultDataProvider()
+     *
      * @param array $dataSet
      */
     public function testResult(array $dataSet, array $rules): void
@@ -75,8 +77,8 @@ abstract class AbstractDataSetTest extends TestCase
                             return $result;
                         },
                     ],
-                ]
-            ]
+                ],
+            ],
         ];
     }
 

--- a/tests/DataSetTest.php
+++ b/tests/DataSetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests;
+
+use Yiisoft\Validator\ResultSet;
+use Yiisoft\Validator\Tests\Stub\DataSet;
+use Yiisoft\Validator\Validator;
+
+final class DataSetTest extends AbstractDataSetTest
+{
+    protected function validate(array $dataSet, array $rules): ResultSet
+    {
+        $dataObject = new DataSet($dataSet);
+
+        $validator = new Validator();
+
+        return $validator->validate($dataObject, $rules);
+    }
+}

--- a/tests/RulesProvidedDataSetTest.php
+++ b/tests/RulesProvidedDataSetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests;
+
+use Yiisoft\Validator\ResultSet;
+use Yiisoft\Validator\Tests\Stub\RulesProvidedDataSet;
+use Yiisoft\Validator\Validator;
+
+final class RulesProvidedDataSetTest extends AbstractDataSetTest
+{
+    protected function validate(array $dataSet, array $rules): ResultSet
+    {
+        $dataObject = new RulesProvidedDataSet($dataSet, $rules);
+
+        $validator = new Validator();
+
+        return $validator->validate($dataObject);
+    }
+}

--- a/tests/Stub/RulesProvidedDataSet.php
+++ b/tests/Stub/RulesProvidedDataSet.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests\Stub;
+
+use Yiisoft\Validator\Exception\MissingAttributeException;
+use Yiisoft\Validator\RulesProviderInterface;
+
+final class RulesProvidedDataSet implements RulesProviderInterface
+{
+    private array $data;
+    private array $rules;
+
+    public function __construct(array $data, array $rules)
+    {
+        $this->data = $data;
+        $this->rules = $rules;
+    }
+
+    public function getAttributeValue(string $attribute)
+    {
+        if (!$this->hasAttribute($attribute)) {
+            throw new MissingAttributeException("There is no \"$attribute\" attribute in the class.");
+        }
+
+        return $this->data[$attribute];
+    }
+
+    public function hasAttribute(string $attribute): bool
+    {
+        return isset($this->data[$attribute]);
+    }
+
+    public function getRules(): iterable
+    {
+        return $this->rules;
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -9,38 +9,72 @@ use Yiisoft\Validator\Result;
 use Yiisoft\Validator\Rule\Boolean;
 use Yiisoft\Validator\Rule\Number;
 use Yiisoft\Validator\Tests\Stub\DataSet;
+use Yiisoft\Validator\Tests\Stub\RulesProvidedDataSet;
 use Yiisoft\Validator\Validator;
 
 class ValidatorTest extends TestCase
 {
-    public function testAddingRulesViaConstructor(): void
+    /**
+     * @dataProvider validationCasesDataProvider()
+     * @param array $dataSet
+     */
+    public function testAddingRulesViaConstructor(array $dataSet, array $rules): void
     {
-        $dataObject = new DataSet([
-            'bool' => true,
-            'int' => 41,
-        ]);
+        $dataObject = new DataSet($dataSet);
 
         $validator = new Validator();
 
-        $results = $validator->validate($dataObject, [
-            'bool' => [new Boolean()],
-            'int' => [
-                (new Number())->integer(),
-                (new Number())->integer()->min(44),
-                static function ($value): Result {
-                    $result = new Result();
-                    if ($value !== 42) {
-                        $result->addError('Value should be 42!');
-                    }
-                    return $result;
-                },
-            ],
-        ]);
+        $results = $validator->validate($dataObject, $rules);
 
         $this->assertTrue($results->getResult('bool')->isValid());
 
         $intResult = $results->getResult('int');
         $this->assertFalse($intResult->isValid());
         $this->assertCount(1, $intResult->getErrors());
+    }
+
+    /**
+     * @dataProvider validationCasesDataProvider()
+     * @param array $dataSet
+     */
+    public function testRulesProvidedObject(array $dataSet, array $rules): void
+    {
+        $dataObject = new RulesProvidedDataSet($dataSet, $rules);
+
+        $validator = new Validator();
+
+        $results = $validator->validate($dataObject);
+
+        $this->assertTrue($results->getResult('bool')->isValid());
+
+        $intResult = $results->getResult('int');
+        $this->assertFalse($intResult->isValid());
+        $this->assertCount(1, $intResult->getErrors());
+    }
+
+    public function validationCasesDataProvider(): array
+    {
+        return [
+            [
+                [
+                    'bool' => true,
+                    'int' => 41,
+                ],
+                [
+                    'bool' => [new Boolean()],
+                    'int' => [
+                        (new Number())->integer(),
+                        (new Number())->integer()->min(44),
+                        static function ($value): Result {
+                            $result = new Result();
+                            if ($value !== 42) {
+                                $result->addError('Value should be 42!');
+                            }
+                            return $result;
+                        },
+                    ],
+                ]
+            ]
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

It adds such of features:
1. Validated object can provided validation rules for itself (e.g. forms) as first and one argument for `ValidatorInterface`.
    `$validator->validate($object)` instead of `$validator->validate($object, $object->getRules())`
2. Delegating validation post-processing to object over public method `processValidationResult`