### PR TITLE
Add getErrorsIndexedByAttribute() and getCommonErrors() methods to Result class

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -73,6 +73,22 @@ final class Result
     }
 
     /**
+     * @psalm-return array<string, non-empty-list<string>>
+     */
+    public function getTopLevelAttributeErrors(): array
+    {
+        $errors = [];
+        foreach ($this->errors as $error) {
+            $firstItem = $error->getValuePath()[0] ?? null;
+            if ($firstItem !== null) {
+                $errors[$firstItem][] = $error->getMessage();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
      * @psalm-return array<string, string[]>
      */
     public function getAttributeErrors(string $attribute): array

--- a/src/Result.php
+++ b/src/Result.php
@@ -73,7 +73,7 @@ final class Result
     }
 
     /**
-     * @psalm-return array<string, non-empty-list<string>>
+     * @psalm-return array<int|string, non-empty-list<int|string>>
      */
     public function getTopLevelAttributeErrors(): array
     {

--- a/src/Result.php
+++ b/src/Result.php
@@ -75,7 +75,7 @@ final class Result
     /**
      * @psalm-return array<int|string, non-empty-list<int|string>>
      */
-    public function getTopLevelAttributeErrors(): array
+    public function getErrorsIndexedByAttribute(): array
     {
         $errors = [];
         foreach ($this->errors as $error) {

--- a/src/Result.php
+++ b/src/Result.php
@@ -25,7 +25,7 @@ final class Result
     public function isAttributeValid(string $attribute): bool
     {
         foreach ($this->errors as $error) {
-            $firstItem = $error->getValuePath()[0] ?? null;
+            $firstItem = $error->getValuePath()[0] ?? '';
             if ($firstItem === $attribute) {
                 return false;
             }
@@ -65,27 +65,25 @@ final class Result
     }
 
     /**
-     * @psalm-return array<string, Error[]>
-     */
-    public function getAttributeErrorObjects(string $attribute): array
-    {
-        return $this->getAttributeErrorsMap($attribute, static fn (Error $error): Error => $error);
-    }
-
-    /**
      * @psalm-return array<int|string, non-empty-list<int|string>>
      */
     public function getErrorsIndexedByAttribute(): array
     {
         $errors = [];
         foreach ($this->errors as $error) {
-            $firstItem = $error->getValuePath()[0] ?? null;
-            if ($firstItem !== null) {
-                $errors[$firstItem][] = $error->getMessage();
-            }
+            $key = $error->getValuePath()[0] ?? '';
+            $errors[$key][] = $error->getMessage();
         }
 
         return $errors;
+    }
+
+    /**
+     * @psalm-return array<string, Error[]>
+     */
+    public function getAttributeErrorObjects(string $attribute): array
+    {
+        return $this->getAttributeErrorsMap($attribute, static fn (Error $error): Error => $error);
     }
 
     /**
@@ -100,7 +98,7 @@ final class Result
     {
         $errors = [];
         foreach ($this->errors as $error) {
-            $firstItem = $error->getValuePath()[0] ?? null;
+            $firstItem = $error->getValuePath()[0] ?? '';
             if ($firstItem === $attribute) {
                 $errors[] = $getErrorClosure($error);
             }
@@ -116,7 +114,7 @@ final class Result
     {
         $errors = [];
         foreach ($this->errors as $error) {
-            $firstItem = $error->getValuePath()[0] ?? null;
+            $firstItem = $error->getValuePath()[0] ?? '';
             if ($firstItem !== $attribute) {
                 continue;
             }

--- a/src/Result.php
+++ b/src/Result.php
@@ -79,7 +79,7 @@ final class Result
     }
 
     /**
-     * @psalm-return array<string, Error[]>
+     * @return Error[]
      */
     public function getAttributeErrorObjects(string $attribute): array
     {
@@ -87,7 +87,7 @@ final class Result
     }
 
     /**
-     * @psalm-return array<string, string[]>
+     * @return string[]
      */
     public function getAttributeErrors(string $attribute): array
     {
@@ -124,6 +124,14 @@ final class Result
         }
 
         return $errors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCommonErrors(): array
+    {
+        return $this->getAttributeErrors('');
     }
 
     /**

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -138,6 +138,11 @@ class ResultTest extends TestCase
         $this->assertEquals(['' => ['error3.1', 'error3.2']], $result->getAttributeErrorsIndexedByPath(''));
     }
 
+    public function testGetCommonErrors(): void
+    {
+        $this->assertEquals(['error3.1', 'error3.2'], $this->createAttributeErrorResult()->getCommonErrors());
+    }
+
     private function createAttributeErrorResult(): Result
     {
         $result = new Result();

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -106,7 +106,7 @@ class ResultTest extends TestCase
     {
         $this->assertEquals(
             ['attribute2' => ['error2.1', 'error2.2', 'error2.3', 'error2.4']],
-            $this->createAttributeErrorResult()->getTopLevelAttributeErrors()
+            $this->createAttributeErrorResult()->getErrorsIndexedByAttribute()
         );
     }
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -102,6 +102,14 @@ class ResultTest extends TestCase
         );
     }
 
+    public function testGetTopLevelAttributeErrors(): void
+    {
+        $this->assertEquals(
+            ['attribute2' => ['error2.1', 'error2.2', 'error2.3', 'error2.4']],
+            $this->createAttributeErrorResult()->getTopLevelAttributeErrors()
+        );
+    }
+
     public function testGetAttributeErrors(): void
     {
         $this->assertEquals([], $this->createAttributeErrorResult()->getAttributeErrors('attribute1'));

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -86,11 +86,22 @@ class ResultTest extends TestCase
 
         $this->assertTrue($result->isAttributeValid('attribute1'));
         $this->assertFalse($result->isAttributeValid('attribute2'));
+        $this->assertFalse($result->isAttributeValid(''));
+    }
+
+    public function testGetErrorsIndexedByAttribute(): void
+    {
+        $this->assertEquals(
+            ['attribute2' => ['error2.1', 'error2.2', 'error2.3', 'error2.4'], '' => ['error3.1', 'error3.2']],
+            $this->createAttributeErrorResult()->getErrorsIndexedByAttribute()
+        );
     }
 
     public function testGetAttributeErrorObjects(): void
     {
-        $this->assertEquals([], $this->createAttributeErrorResult()->getAttributeErrorObjects('attribute1'));
+        $result = $this->createAttributeErrorResult();
+
+        $this->assertEquals([], $result->getAttributeErrorObjects('attribute1'));
         $this->assertEquals(
             [
                 new Error('error2.1', ['attribute2']),
@@ -98,34 +109,33 @@ class ResultTest extends TestCase
                 new Error('error2.3', ['attribute2', 'nested']),
                 new Error('error2.4', ['attribute2', 'nested']),
             ],
-            $this->createAttributeErrorResult()->getAttributeErrorObjects('attribute2')
+            $result->getAttributeErrorObjects('attribute2')
         );
-    }
-
-    public function testGetTopLevelAttributeErrors(): void
-    {
-        $this->assertEquals(
-            ['attribute2' => ['error2.1', 'error2.2', 'error2.3', 'error2.4']],
-            $this->createAttributeErrorResult()->getErrorsIndexedByAttribute()
-        );
+        $this->assertEquals([new Error('error3.1'), new Error('error3.2')], $result->getAttributeErrorObjects(''));
     }
 
     public function testGetAttributeErrors(): void
     {
-        $this->assertEquals([], $this->createAttributeErrorResult()->getAttributeErrors('attribute1'));
+        $result = $this->createAttributeErrorResult();
+
+        $this->assertEquals([], $result->getAttributeErrors('attribute1'));
         $this->assertEquals(
             ['error2.1', 'error2.2', 'error2.3', 'error2.4'],
-            $this->createAttributeErrorResult()->getAttributeErrors('attribute2')
+            $result->getAttributeErrors('attribute2')
         );
+        $this->assertEquals(['error3.1', 'error3.2'], $result->getAttributeErrors(''));
     }
 
     public function testGetAttributeErrorsIndexedByPath(): void
     {
-        $this->assertEquals([], $this->createAttributeErrorResult()->getAttributeErrorsIndexedByPath('attribute1'));
+        $result = $this->createAttributeErrorResult();
+
+        $this->assertEquals([], $result->getAttributeErrorsIndexedByPath('attribute1'));
         $this->assertEquals(
             ['' => ['error2.1', 'error2.2'], 'nested' => ['error2.3', 'error2.4']],
-            $this->createAttributeErrorResult()->getAttributeErrorsIndexedByPath('attribute2')
+            $result->getAttributeErrorsIndexedByPath('attribute2')
         );
+        $this->assertEquals(['' => ['error3.1', 'error3.2']], $result->getAttributeErrorsIndexedByPath(''));
     }
 
     private function createAttributeErrorResult(): Result
@@ -135,6 +145,8 @@ class ResultTest extends TestCase
         $result->addError('error2.2', ['attribute2']);
         $result->addError('error2.3', ['attribute2', 'nested']);
         $result->addError('error2.4', ['attribute2', 'nested']);
+        $result->addError('error3.1');
+        $result->addError('error3.2');
 
         return $result;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | Related - https://github.com/yiisoft/form/issues/177
