### PR TITLE
Implement self-validatable callback rule

### DIFF
--- a/src/Rule/SelfValidatableRuleInterface.php
+++ b/src/Rule/SelfValidatableRuleInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Rule;
+
+use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleInterface;
+use Yiisoft\Validator\ValidationContext;
+
+/**
+ * Rule handler performs actual validation taking configuration parameters from a rule.
+ */
+interface SelfValidatableRuleInterface extends RuleInterface
+{
+    /**
+     * Validates the value.
+     *
+     * @param mixed $value Value to be validated.
+     * @param ValidationContext|null $context Optional validation context.
+     *
+     * @return Result
+     */
+    public function validate(mixed $value, ?ValidationContext $context = null): Result;
+}

--- a/tests/Rule/SelfValidatable/AbstractSelfValidatableRuleTest.php
+++ b/tests/Rule/SelfValidatable/AbstractSelfValidatableRuleTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests\Rule\SelfValidatable;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Yiisoft\Validator\Exception\UnexpectedRuleException;
+use Yiisoft\Validator\Formatter;
+use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\Result;
+use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\Rule\SelfValidatableRuleInterface;
+use Yiisoft\Validator\Tests\Stub\FakeValidatorFactory;
+use Yiisoft\Validator\ValidationContext;
+
+abstract class AbstractSelfValidatableRuleTest extends TestCase
+{
+    /**
+     * @dataProvider passedValidationProvider
+     */
+    public function testValidationPassed(SelfValidatableRuleInterface $rule, mixed $value): void
+    {
+        $result = $this->validate($rule, $value);
+
+        $this->assertTrue($result->isValid(), print_r($result->getErrors(), true));
+    }
+
+    /**
+     * @dataProvider failedValidationProvider
+     */
+    public function testValidationFailed(SelfValidatableRuleInterface $rule, mixed $value, array $expectedErrors): void
+    {
+        $result = $this->validate($rule, $value);
+
+        $this->assertFalse($result->isValid(), print_r($result->getErrors(), true));
+        $this->assertEquals($expectedErrors, $result->getErrors());
+    }
+
+    /**
+     * @param string[] $expectedErrorMessages
+     *
+     * @dataProvider customErrorMessagesProvider
+     */
+    public function testCustomErrorMessages(SelfValidatableRuleInterface $rule, mixed $value, array $expectedErrorMessages): void
+    {
+        $result = $this->validate($rule, $value);
+
+        $errors = $result->getErrors();
+
+        $this->assertFalse($result->isValid(), print_r($result->getErrors(), true));
+        $this->assertEquals($expectedErrorMessages, $errors);
+    }
+
+    protected function validate(SelfValidatableRuleInterface $rule, mixed $value): Result
+    {
+        $context = new ValidationContext(FakeValidatorFactory::make(), null);
+
+        return $rule->validate($value, $context);
+    }
+
+    abstract public function customErrorMessagesProvider(): array;
+
+    abstract public function passedValidationProvider(): array;
+
+    abstract public function failedValidationProvider(): array;
+
+    /**
+     * @dataProvider optionsDataProvider
+     */
+    public function testOptions(SelfValidatableRuleInterface $rule, array $expectedOptions): void
+    {
+        $options = $rule->getOptions();
+
+        $this->assertEquals($expectedOptions, $options);
+    }
+
+    public function testGetName(): void
+    {
+        $rule = $this->getRule();
+        $this->assertEquals(lcfirst(substr($rule::class, strrpos($rule::class, '\\') + 1)), $rule->getName());
+    }
+
+    abstract protected function optionsDataProvider(): array;
+
+    abstract protected function getRule(): SelfValidatableRuleInterface;
+}

--- a/tests/Rule/SelfValidatable/AbstractSelfValidatableRuleTest.php
+++ b/tests/Rule/SelfValidatable/AbstractSelfValidatableRuleTest.php
@@ -5,12 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule\SelfValidatable;
 
 use PHPUnit\Framework\TestCase;
-use stdClass;
-use Yiisoft\Validator\Exception\UnexpectedRuleException;
-use Yiisoft\Validator\Formatter;
-use Yiisoft\Validator\ParametrizedRuleInterface;
 use Yiisoft\Validator\Result;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
 use Yiisoft\Validator\Rule\SelfValidatableRuleInterface;
 use Yiisoft\Validator\Tests\Stub\FakeValidatorFactory;
 use Yiisoft\Validator\ValidationContext;

--- a/tests/Rule/SelfValidatable/CallbackSelfValidatableTest.php
+++ b/tests/Rule/SelfValidatable/CallbackSelfValidatableTest.php
@@ -6,14 +6,11 @@ namespace Yiisoft\Validator\Tests\Rule\SelfValidatable;
 
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Exception\InvalidCallbackReturnTypeException;
-use Yiisoft\Validator\ParametrizedRuleInterface;
 use Yiisoft\Validator\Result;
-use Yiisoft\Validator\Rule\AtLeast;
-use Yiisoft\Validator\Rule\Callback;
 use Yiisoft\Validator\Rule\SelfValidatableRuleInterface;
 use Yiisoft\Validator\Tests\Stub\CallbackSelfValidatableRule;
 
-final class CallbackHandlerTest extends AbstractSelfValidatableRuleTest
+final class CallbackSelfValidatableTest extends AbstractSelfValidatableRuleTest
 {
     public function failedValidationProvider(): array
     {
@@ -96,7 +93,6 @@ final class CallbackHandlerTest extends AbstractSelfValidatableRuleTest
             ],
         ];
     }
-
 
     protected function getRule(): SelfValidatableRuleInterface
     {

--- a/tests/Rule/SelfValidatable/CallbackSelfValidatableTest.php
+++ b/tests/Rule/SelfValidatable/CallbackSelfValidatableTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests\Rule\SelfValidatable;
+
+use Yiisoft\Validator\Error;
+use Yiisoft\Validator\Exception\InvalidCallbackReturnTypeException;
+use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\Result;
+use Yiisoft\Validator\Rule\AtLeast;
+use Yiisoft\Validator\Rule\Callback;
+use Yiisoft\Validator\Rule\SelfValidatableRuleInterface;
+use Yiisoft\Validator\Tests\Stub\CallbackSelfValidatableRule;
+
+final class CallbackHandlerTest extends AbstractSelfValidatableRuleTest
+{
+    public function failedValidationProvider(): array
+    {
+        return [
+            [
+                new CallbackSelfValidatableRule(static function ($value): Result {
+                    $result = new Result();
+                    if ($value !== 42) {
+                        $result->addError('Value should be 42!');
+                    }
+
+                    return $result;
+                }),
+                41,
+                [new Error('Value should be 42!', [])],
+            ],
+        ];
+    }
+
+    public function passedValidationProvider(): array
+    {
+        return [
+            [
+                new CallbackSelfValidatableRule(static function ($value): Result {
+                    $result = new Result();
+                    if ($value !== 42) {
+                        $result->addError('Value should be 42!');
+                    }
+
+                    return $result;
+                }),
+                42,
+            ],
+        ];
+    }
+
+    public function customErrorMessagesProvider(): array
+    {
+        return [
+            [
+                new CallbackSelfValidatableRule(static function ($value): Result {
+                    $result = new Result();
+                    if ($value !== 42) {
+                        $result->addError('Custom error', []);
+                    }
+
+                    return $result;
+                }),
+                41,
+                [new Error('Custom error', [])],
+            ],
+        ];
+    }
+
+    public function testThrowExceptionWithInvalidReturn(): void
+    {
+        $this->expectException(InvalidCallbackReturnTypeException::class);
+
+        $rule = new CallbackSelfValidatableRule(static fn (): string => 'invalid return');
+
+        $rule->validate(null);
+    }
+
+    public function optionsDataProvider(): array
+    {
+        return [
+            [
+                new CallbackSelfValidatableRule(static fn ($value) => $value),
+                [
+                    'skipOnEmpty' => false,
+                    'skipOnError' => false,
+                ],
+            ],
+            [
+                new CallbackSelfValidatableRule(static fn ($value) => $value, skipOnEmpty: true),
+                [
+                    'skipOnEmpty' => true,
+                    'skipOnError' => false,
+                ],
+            ],
+        ];
+    }
+
+
+    protected function getRule(): SelfValidatableRuleInterface
+    {
+        return new CallbackSelfValidatableRule([]);
+    }
+}

--- a/tests/Stub/CallbackSelfValidatableRule.php
+++ b/tests/Stub/CallbackSelfValidatableRule.php
@@ -6,16 +6,12 @@ namespace Yiisoft\Validator\Tests\Stub;
 
 use Closure;
 use Yiisoft\Validator\Exception\InvalidCallbackReturnTypeException;
-use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
-use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
-use Yiisoft\Validator\Rule\Callback;
 use Yiisoft\Validator\Rule\SelfValidatableRuleInterface;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\RuleNameTrait;
-use Yiisoft\Validator\RuleInterface;
 use Yiisoft\Validator\ValidationContext;
 
 class CallbackSelfValidatableRule implements SelfValidatableRuleInterface

--- a/tests/Stub/CallbackSelfValidatableRule.php
+++ b/tests/Stub/CallbackSelfValidatableRule.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests\Stub;
+
+use Closure;
+use Yiisoft\Validator\Exception\InvalidCallbackReturnTypeException;
+use Yiisoft\Validator\Exception\UnexpectedRuleException;
+use Yiisoft\Validator\Formatter;
+use Yiisoft\Validator\FormatterInterface;
+use Yiisoft\Validator\Result;
+use Yiisoft\Validator\Rule\Callback;
+use Yiisoft\Validator\Rule\SelfValidatableRuleInterface;
+use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
+use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
+use Yiisoft\Validator\Rule\Trait\RuleNameTrait;
+use Yiisoft\Validator\RuleInterface;
+use Yiisoft\Validator\ValidationContext;
+
+class CallbackSelfValidatableRule implements SelfValidatableRuleInterface
+{
+    use BeforeValidationTrait;
+    use HandlerClassNameTrait;
+    use RuleNameTrait;
+
+    private Formatter $formatter;
+
+    public function __construct(
+        /**
+         * @var callable
+         */
+        private $callback,
+        private bool $skipOnEmpty = false,
+        private bool $skipOnError = false,
+        /**
+         * @var Closure(mixed, ValidationContext):bool|null
+         */
+        private ?Closure $when = null,
+    ) {
+        $this->formatter = new Formatter();
+    }
+
+    /**
+     * @return callable
+     */
+    public function getCallback(): callable
+    {
+        return $this->callback;
+    }
+
+    #[ArrayShape(['skipOnEmpty' => 'bool', 'skipOnError' => 'bool'])]
+    public function getOptions(): array
+    {
+        return [
+            'skipOnEmpty' => $this->skipOnEmpty,
+            'skipOnError' => $this->skipOnError,
+        ];
+    }
+
+    public function validate(mixed $value, ?ValidationContext $context = null): Result
+    {
+        $callback = $this->getCallback();
+        $callbackResult = $callback($value, $context);
+
+        if (!$callbackResult instanceof Result) {
+            throw new InvalidCallbackReturnTypeException($callbackResult);
+        }
+
+        $result = new Result();
+        if ($callbackResult->isValid()) {
+            return $result;
+        }
+
+        foreach ($callbackResult->getErrors() as $error) {
+            $formattedMessage = $this->formatter->format(
+                $error->getMessage(),
+                ['attribute' => $context?->getAttribute(), 'value' => $value]
+            );
+            $result->addError($formattedMessage, $error->getValuePath());
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Implemented self-validated, a.k.a. "simple rule".
It's an example to discuss shall we support this approach using validator.

Just copied almost all methods from `Callback` rule, its handler and tests.


You can compare the sources of simple and "not simple" rules.
[Original rule](https://github.com/yiisoft/validator/blob/a1ad9783ada37fc8504117fe61f4b697877dd7a7/src/Rule/Callback.php) and its [handler](https://github.com/yiisoft/validator/blob/a1ad9783ada37fc8504117fe61f4b697877dd7a7/src/Rule/CallbackHandler.php).
VS
[Simple rule](https://github.com/yiisoft/validator/blob/a1ad9783ada37fc8504117fe61f4b697877dd7a7/tests/Stub/CallbackSelfValidatableRule.php).

The main advantage to have it:
**Simple to write, read and support.** 

Even when the `validate` method doesn't have the check on type of the argument it looks worse.
1. Mixed responsibility. One class has either config and validation. Validation calls when the class passes to `$validator->validate()` method. Some of delayed calls. Isn't remember something? Yii2-queue has similar way. If you use Yii2-queue the job will be serialized and deserialized before it will be processed. Yii2-queue is being replacing with queue that won't have this drawback. So implementing the "simple" rule as I did we will back to already went mistakes.
2. Just try to inject some service into it. You need to implement something like service-aware service that will set needed properties with a lot magic under hood. It kills all "simple" approach.2. Just try to inject some service into it. You need to implement something like service-aware service that will set needed properties with a lot magic under hood. It kills all "simple" approach.

Any "simple" checks could be done with callback rule.