### PR TITLE
Refactor interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ use Attribute;
 use \Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Result;
 use Yiisoft\Validator\Rule\Number;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use \Yiisoft\Validator\RuleInterface;
 use Yiisoft\Validator\ValidationContext;
 
@@ -563,7 +563,7 @@ namespace MyVendor\Rules;
 
 use Yiisoft\Validator\DataSetInterface;
 use Yiisoft\Validator\Exception\UnexpectedRuleException;use Yiisoft\Validator\FormatterInterface;use Yiisoft\Validator\Result;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;use Yiisoft\Validator\RuleInterface;
+use Yiisoft\Validator\RuleHandlerInterface;use Yiisoft\Validator\RuleInterface;
 
 final class PiHandler implements RuleHandlerInterface
 {

--- a/src/Exception/RuleHandlerInterfaceNotImplementedException.php
+++ b/src/Exception/RuleHandlerInterfaceNotImplementedException.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Exception;
 
 use RuntimeException;
 use Throwable;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class RuleHandlerInterfaceNotImplementedException extends RuntimeException
 {

--- a/src/Rule/AtLeast.php
+++ b/src/Rule/AtLeast.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -18,7 +18,7 @@ use Yiisoft\Validator\ValidationContext;
  * Checks if at least {@see AtLeast::$min} of many attributes are filled.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class AtLeast implements ParametrizedRuleInterface, BeforeValidationInterface
+final class AtLeast implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/AtLeastHandler.php
+++ b/src/Rule/AtLeastHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
 use Yiisoft\Validator\Rule\Trait\EmptyCheckTrait;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 /**

--- a/src/Rule/Boolean.php
+++ b/src/Rule/Boolean.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -18,7 +18,7 @@ use Yiisoft\Validator\ValidationContext;
  * Checks if the value is a boolean value or a value corresponding to it.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Boolean implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Boolean implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/BooleanHandler.php
+++ b/src/Rule/BooleanHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 /**

--- a/src/Rule/Callback.php
+++ b/src/Rule/Callback.php
@@ -6,14 +6,14 @@ namespace Yiisoft\Validator\Rule;
 
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
 use Yiisoft\Validator\Rule\Trait\RuleNameTrait;
 use Yiisoft\Validator\ValidationContext;
 
-final class Callback implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Callback implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/CallbackHandler.php
+++ b/src/Rule/CallbackHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 final class CallbackHandler implements RuleHandlerInterface

--- a/src/Rule/Compare.php
+++ b/src/Rule/Compare.php
@@ -9,13 +9,13 @@ use InvalidArgumentException;
 use JetBrains\PhpStorm\ArrayShape;
 use RuntimeException;
 use Yiisoft\Validator\BeforeValidationInterface;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\RuleNameTrait;
 use Yiisoft\Validator\ValidationContext;
 
-abstract class Compare implements ParametrizedRuleInterface, BeforeValidationInterface
+abstract class Compare implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/CompareHandler.php
+++ b/src/Rule/CompareHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 /**

--- a/src/Rule/Composite.php
+++ b/src/Rule/Composite.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use Yiisoft\Validator\BeforeValidationInterface;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\RuleNameTrait;
@@ -18,7 +18,7 @@ use Yiisoft\Validator\ValidationContext;
  * Validates that the value is a valid json.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Composite implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Composite implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;
@@ -42,7 +42,7 @@ final class Composite implements ParametrizedRuleInterface, BeforeValidationInte
     {
         $arrayOfRules = [];
         foreach ($this->rules as $rule) {
-            if ($rule instanceof ParametrizedRuleInterface) {
+            if ($rule instanceof SerializableRuleInterface) {
                 $arrayOfRules[] = array_merge([$rule->getName()], $rule->getOptions());
             } else {
                 $arrayOfRules[] = [$rule->getName()];

--- a/src/Rule/CompositeHandler.php
+++ b/src/Rule/CompositeHandler.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Result;
 use Yiisoft\Validator\Rule\Trait\PreValidateTrait;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 /**

--- a/src/Rule/Count.php
+++ b/src/Rule/Count.php
@@ -9,7 +9,7 @@ use Closure;
 use Countable;
 use InvalidArgumentException;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -21,7 +21,7 @@ use Yiisoft\Validator\ValidationContext;
  * {@see Countable} interface.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Count implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Count implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/CountHandler.php
+++ b/src/Rule/CountHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function count;

--- a/src/Rule/Each.php
+++ b/src/Rule/Each.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Rule;
 
 use Attribute;
 use Closure;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -18,7 +18,7 @@ use Yiisoft\Validator\ValidationContext;
  * Validates an array by checking each of its elements against a set of rules.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Each implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Each implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;
@@ -68,7 +68,7 @@ final class Each implements ParametrizedRuleInterface, BeforeValidationInterface
     {
         $arrayOfRules = [];
         foreach ($this->rules as $rule) {
-            if ($rule instanceof ParametrizedRuleInterface) {
+            if ($rule instanceof SerializableRuleInterface) {
                 $arrayOfRules[] = array_merge([$rule->getName()], $rule->getOptions());
             } else {
                 $arrayOfRules[] = [$rule->getName()];

--- a/src/Rule/EachHandler.php
+++ b/src/Rule/EachHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\RuleInterface;
 use Yiisoft\Validator\ValidationContext;
 

--- a/src/Rule/Email.php
+++ b/src/Rule/Email.php
@@ -8,7 +8,7 @@ use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
 use RuntimeException;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -22,7 +22,7 @@ use function function_exists;
  * Validates that the value is a valid email address.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Email implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Email implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/EmailHandler.php
+++ b/src/Rule/EmailHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_string;

--- a/src/Rule/GroupRule.php
+++ b/src/Rule/GroupRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Rule;
 
 use Closure;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -16,7 +16,7 @@ use Yiisoft\Validator\ValidationContext;
 /**
  * Validates a single value for a set of custom rules.
  */
-abstract class GroupRule implements ParametrizedRuleInterface, BeforeValidationInterface
+abstract class GroupRule implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/GroupRuleHandler.php
+++ b/src/Rule/GroupRuleHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 /**

--- a/src/Rule/HasLength.php
+++ b/src/Rule/HasLength.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -20,7 +20,7 @@ use Yiisoft\Validator\ValidationContext;
  * Note, this rule should only be used with strings.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class HasLength implements ParametrizedRuleInterface, BeforeValidationInterface
+final class HasLength implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/HasLengthHandler.php
+++ b/src/Rule/HasLengthHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_string;

--- a/src/Rule/InRange.php
+++ b/src/Rule/InRange.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -21,7 +21,7 @@ use Yiisoft\Validator\ValidationContext;
  * If the {@see InRange::$not} is called, the rule will ensure the value is NOT among the specified range.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class InRange implements ParametrizedRuleInterface, BeforeValidationInterface
+final class InRange implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/InRangeHandler.php
+++ b/src/Rule/InRangeHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 /**

--- a/src/Rule/Ip.php
+++ b/src/Rule/Ip.php
@@ -8,7 +8,7 @@ use Attribute;
 use Closure;
 use RuntimeException;
 use Yiisoft\NetworkUtilities\IpHelper;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -25,7 +25,7 @@ use function strlen;
  * It also may change the value if normalization of IPv6 expansion is enabled.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Ip implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Ip implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/IpHandler.php
+++ b/src/Rule/IpHandler.php
@@ -11,6 +11,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_string;

--- a/src/Rule/Json.php
+++ b/src/Rule/Json.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -18,7 +18,7 @@ use Yiisoft\Validator\ValidationContext;
  * Validates that the value is a valid json.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Json implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Json implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/JsonHandler.php
+++ b/src/Rule/JsonHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_string;

--- a/src/Rule/Nested.php
+++ b/src/Rule/Nested.php
@@ -8,7 +8,7 @@ use Attribute;
 use Closure;
 use InvalidArgumentException;
 use Traversable;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -24,7 +24,7 @@ use function is_array;
  * Can be used for validation of nested structures.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Nested implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Nested implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/NestedHandler.php
+++ b/src/Rule/NestedHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_array;

--- a/src/Rule/Number.php
+++ b/src/Rule/Number.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Rule;
 
 use Attribute;
 use Closure;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -21,7 +21,7 @@ use Yiisoft\Validator\ValidationContext;
  * to ensure the number is within certain range.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Number implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Number implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/NumberHandler.php
+++ b/src/Rule/NumberHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 /**

--- a/src/Rule/Regex.php
+++ b/src/Rule/Regex.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -20,7 +20,7 @@ use Yiisoft\Validator\ValidationContext;
  * If the {@see Regex::$not} is used, the rule will ensure the value do NOT match the pattern.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Regex implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Regex implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/RegexHandler.php
+++ b/src/Rule/RegexHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_string;

--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -18,7 +18,7 @@ use Yiisoft\Validator\ValidationContext;
  * Validates that the specified value is neither null nor empty.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Required implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Required implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/RequiredHandler.php
+++ b/src/Rule/RequiredHandler.php
@@ -9,6 +9,7 @@ use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
 use Yiisoft\Validator\Rule\Trait\EmptyCheckTrait;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_string;

--- a/src/Rule/Subset.php
+++ b/src/Rule/Subset.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Rule;
 use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -15,7 +15,7 @@ use Yiisoft\Validator\Rule\Trait\RuleNameTrait;
 use Yiisoft\Validator\ValidationContext;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Subset implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Subset implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/SubsetHandler.php
+++ b/src/Rule/SubsetHandler.php
@@ -10,6 +10,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 final class SubsetHandler implements RuleHandlerInterface

--- a/src/Rule/Url.php
+++ b/src/Rule/Url.php
@@ -8,7 +8,7 @@ use Attribute;
 use Closure;
 use JetBrains\PhpStorm\ArrayShape;
 use RuntimeException;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -22,7 +22,7 @@ use Yiisoft\Validator\ValidationContext;
  * It does not check the remaining parts of a URL.
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class Url implements ParametrizedRuleInterface, BeforeValidationInterface
+final class Url implements SerializableRuleInterface, BeforeValidationInterface
 {
     use BeforeValidationTrait;
     use HandlerClassNameTrait;

--- a/src/Rule/UrlHandler.php
+++ b/src/Rule/UrlHandler.php
@@ -8,6 +8,7 @@ use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\FormatterInterface;
 use Yiisoft\Validator\Result;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function is_string;

--- a/src/RuleHandlerContainer.php
+++ b/src/RuleHandlerContainer.php
@@ -8,7 +8,6 @@ use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Yiisoft\Validator\Exception\RuleHandlerInterfaceNotImplementedException;
 use Yiisoft\Validator\Exception\RuleHandlerNotFoundException;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
 
 final class RuleHandlerContainer implements RuleHandlerResolverInterface
 {

--- a/src/RuleHandlerInterface.php
+++ b/src/RuleHandlerInterface.php
@@ -2,10 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Validator\Rule;
-
-use Yiisoft\Validator\Result;
-use Yiisoft\Validator\ValidationContext;
+namespace Yiisoft\Validator;
 
 /**
  * Rule handler performs actual validation taking configuration parameters from a rule.

--- a/src/RuleHandlerResolverInterface.php
+++ b/src/RuleHandlerResolverInterface.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Validator;
 
 use Yiisoft\Validator\Exception\RuleHandlerInterfaceNotImplementedException;
 use Yiisoft\Validator\Exception\RuleHandlerNotFoundException;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
 
 /**
  * Rule handler resolver is obtaining a resolver for a given rule class name.

--- a/src/RulesDumper.php
+++ b/src/RulesDumper.php
@@ -11,7 +11,7 @@ use function is_array;
  * RulesDumper allows to get an array of rule names and corresponding settings from a set of rules.
  * The array is usually passed to the client to use it in client-side validation.
  *
- * * @see ParametrizedRuleInterface
+ * * @see SerializableRuleInterface
  * * @see RuleInterface
  */
 final class RulesDumper
@@ -58,7 +58,7 @@ final class RulesDumper
         foreach ($rules as $attribute => $rule) {
             if (is_array($rule)) {
                 $result[$attribute] = $this->fetchOptions($rule);
-            } elseif ($rule instanceof ParametrizedRuleInterface) {
+            } elseif ($rule instanceof SerializableRuleInterface) {
                 $result[$attribute] = array_merge([$rule->getName()], $rule->getOptions());
             } elseif ($rule instanceof RuleInterface) {
                 $result[$attribute] = [$rule->getName()];

--- a/src/SerializableRuleInterface.php
+++ b/src/SerializableRuleInterface.php
@@ -8,7 +8,7 @@ namespace Yiisoft\Validator;
  * The interface should be implemented for a rule that is meant to be converted to array of name => parameters.
  * Such array is usually passed to the client and then used for client-side validation.
  */
-interface ParametrizedRuleInterface extends RuleInterface
+interface SerializableRuleInterface extends RuleInterface
 {
     /**
      * Returns rule options as array.

--- a/src/SimpleRuleHandlerContainer.php
+++ b/src/SimpleRuleHandlerContainer.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Validator;
 
 use Yiisoft\Validator\Exception\RuleHandlerInterfaceNotImplementedException;
 use Yiisoft\Validator\Exception\RuleHandlerNotFoundException;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
 
 final class SimpleRuleHandlerContainer implements RuleHandlerResolverInterface
 {

--- a/tests/Rule/AbstractRuleTest.php
+++ b/tests/Rule/AbstractRuleTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\SimpleRuleHandlerContainer;
 
 abstract class AbstractRuleTest extends TestCase
@@ -13,7 +13,7 @@ abstract class AbstractRuleTest extends TestCase
     /**
      * @dataProvider optionsDataProvider
      */
-    public function testOptions(ParametrizedRuleInterface $rule, array $expectedOptions): void
+    public function testOptions(SerializableRuleInterface $rule, array $expectedOptions): void
     {
         $options = $rule->getOptions();
 
@@ -35,5 +35,5 @@ abstract class AbstractRuleTest extends TestCase
 
     abstract protected function optionsDataProvider(): array;
 
-    abstract protected function getRule(): ParametrizedRuleInterface;
+    abstract protected function getRule(): SerializableRuleInterface;
 }

--- a/tests/Rule/AbstractRuleValidatorTest.php
+++ b/tests/Rule/AbstractRuleValidatorTest.php
@@ -10,7 +10,7 @@ use Yiisoft\Validator\DataSet\ArrayDataSet;
 use Yiisoft\Validator\Exception\UnexpectedRuleException;
 use Yiisoft\Validator\Formatter;
 use Yiisoft\Validator\Result;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\Tests\Stub\FakeValidatorFactory;
 use Yiisoft\Validator\ValidationContext;
 

--- a/tests/Rule/AtLeastHandlerTest.php
+++ b/tests/Rule/AtLeastHandlerTest.php
@@ -8,7 +8,7 @@ use stdClass;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\AtLeast;
 use Yiisoft\Validator\Rule\AtLeastHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class AtLeastHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/AtLeastTest.php
+++ b/tests/Rule/AtLeastTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\AtLeast;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class AtLeastTest extends AbstractRuleTest
 {
@@ -45,7 +45,7 @@ final class AtLeastTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new AtLeast([]);
     }

--- a/tests/Rule/BooleanHandlerTest.php
+++ b/tests/Rule/BooleanHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Boolean;
 use Yiisoft\Validator\Rule\BooleanHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class BooleanHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/BooleanTest.php
+++ b/tests/Rule/BooleanTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Boolean;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class BooleanTest extends AbstractRuleTest
 {
@@ -134,7 +134,7 @@ final class BooleanTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Boolean([]);
     }

--- a/tests/Rule/CallbackHandlerTest.php
+++ b/tests/Rule/CallbackHandlerTest.php
@@ -9,7 +9,7 @@ use Yiisoft\Validator\Exception\InvalidCallbackReturnTypeException;
 use Yiisoft\Validator\Result;
 use Yiisoft\Validator\Rule\Callback;
 use Yiisoft\Validator\Rule\CallbackHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class CallbackHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/CallbackTest.php
+++ b/tests/Rule/CallbackTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\AtLeast;
 use Yiisoft\Validator\Rule\Callback;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class CallbackTest extends AbstractRuleTest
 {
@@ -30,7 +30,7 @@ final class CallbackTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new AtLeast([]);
     }

--- a/tests/Rule/CompareToHandlerTest.php
+++ b/tests/Rule/CompareToHandlerTest.php
@@ -8,7 +8,7 @@ use Yiisoft\Validator\DataSet\ArrayDataSet;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\CompareTo;
 use Yiisoft\Validator\Rule\CompareHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\Tests\Stub\FakeValidatorFactory;
 use Yiisoft\Validator\ValidationContext;
 

--- a/tests/Rule/CompareToTest.php
+++ b/tests/Rule/CompareToTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Validator\Tests\Rule;
 
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\Rule\CompareTo;
 
 final class CompareToTest extends AbstractRuleTest
@@ -186,7 +186,7 @@ final class CompareToTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new CompareTo(1);
     }

--- a/tests/Rule/CompositeHandlerTest.php
+++ b/tests/Rule/CompositeHandlerTest.php
@@ -8,7 +8,7 @@ use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Composite;
 use Yiisoft\Validator\Rule\CompositeHandler;
 use Yiisoft\Validator\Rule\Number;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class CompositeHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/CompositeTest.php
+++ b/tests/Rule/CompositeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Validator\Tests\Rule;
 
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\Rule\Composite;
 use Yiisoft\Validator\Rule\Number;
 
@@ -66,7 +66,7 @@ final class CompositeTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Composite([]);
     }

--- a/tests/Rule/CountHandlerTest.php
+++ b/tests/Rule/CountHandlerTest.php
@@ -9,7 +9,7 @@ use stdClass;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Count;
 use Yiisoft\Validator\Rule\CountHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class CountHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/CountTest.php
+++ b/tests/Rule/CountTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 
 use InvalidArgumentException;
 use Yiisoft\Validator\Rule\Count;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class CountTest extends AbstractRuleTest
 {
@@ -77,7 +77,7 @@ final class CountTest extends AbstractRuleTest
         new Count();
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Count(min: 1);
     }

--- a/tests/Rule/EachHandlerTest.php
+++ b/tests/Rule/EachHandlerTest.php
@@ -8,7 +8,7 @@ use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Each;
 use Yiisoft\Validator\Rule\EachHandler;
 use Yiisoft\Validator\Rule\Number;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class EachHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/EachTest.php
+++ b/tests/Rule/EachTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Each;
 use Yiisoft\Validator\Rule\Number;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class EachTest extends AbstractRuleTest
 {
@@ -66,7 +66,7 @@ final class EachTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Each([]);
     }

--- a/tests/Rule/EmailHandlerTest.php
+++ b/tests/Rule/EmailHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Email;
 use Yiisoft\Validator\Rule\EmailHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class EmailHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/EmailTest.php
+++ b/tests/Rule/EmailTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Email;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class EmailTest extends AbstractRuleTest
 {
@@ -79,7 +79,7 @@ final class EmailTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Email();
     }

--- a/tests/Rule/EqualHandlerTest.php
+++ b/tests/Rule/EqualHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\CompareHandler;
 use Yiisoft\Validator\Rule\Equal;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class EqualHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/EqualTest.php
+++ b/tests/Rule/EqualTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Equal;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class EqualTest extends AbstractRuleTest
 {
@@ -175,7 +175,7 @@ final class EqualTest extends AbstractRuleTest
         $rule = new Equal();
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Equal(1);
     }

--- a/tests/Rule/GreaterThanHandlerTest.php
+++ b/tests/Rule/GreaterThanHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\CompareHandler;
 use Yiisoft\Validator\Rule\GreaterThan;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class GreaterThanHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/GreaterThanOrEqualHandlerTest.php
+++ b/tests/Rule/GreaterThanOrEqualHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\CompareHandler;
 use Yiisoft\Validator\Rule\GreaterThanOrEqual;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class GreaterThanOrEqualHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/GreaterThanOrEqualTest.php
+++ b/tests/Rule/GreaterThanOrEqualTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\GreaterThanOrEqual;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class GreaterThanOrEqualTest extends AbstractRuleTest
 {
@@ -118,7 +118,7 @@ final class GreaterThanOrEqualTest extends AbstractRuleTest
         $rule = new GreaterThanOrEqual();
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new GreaterThanOrEqual(1);
     }

--- a/tests/Rule/GreaterThanTest.php
+++ b/tests/Rule/GreaterThanTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\GreaterThan;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class GreaterThanTest extends AbstractRuleTest
 {
@@ -118,7 +118,7 @@ final class GreaterThanTest extends AbstractRuleTest
         $rule = new GreaterThan();
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new GreaterThan(1);
     }

--- a/tests/Rule/GroupRuleHandlerTest.php
+++ b/tests/Rule/GroupRuleHandlerTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\GroupRuleHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\Tests\FunctionExists;
 use Yiisoft\Validator\Tests\Stub\CustomUrlRule;
 

--- a/tests/Rule/GroupRuleTest.php
+++ b/tests/Rule/GroupRuleTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Validator\Tests\Rule;
 
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\Tests\FunctionExists;
 use Yiisoft\Validator\Tests\Stub\CustomUrlRule;
 
@@ -65,7 +65,7 @@ final class GroupRuleTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new CustomUrlRule();
     }

--- a/tests/Rule/InRangeHandlerTest.php
+++ b/tests/Rule/InRangeHandlerTest.php
@@ -8,7 +8,7 @@ use ArrayObject;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\InRange;
 use Yiisoft\Validator\Rule\InRangeHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class InRangeHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/InRangeTest.php
+++ b/tests/Rule/InRangeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\InRange;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class InRangeTest extends AbstractRuleTest
 {
@@ -54,7 +54,7 @@ final class InRangeTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new InRange([]);
     }

--- a/tests/Rule/IpHandlerTest.php
+++ b/tests/Rule/IpHandlerTest.php
@@ -8,7 +8,7 @@ use RuntimeException;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Ip;
 use Yiisoft\Validator\Rule\IpHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class IpHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/IpTest.php
+++ b/tests/Rule/IpTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 
 use RuntimeException;
 use Yiisoft\Validator\Rule\Ip;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class IpTest extends AbstractRuleTest
 {
@@ -332,7 +332,7 @@ final class IpTest extends AbstractRuleTest
         new Ip(networks: ['*' => ['wrong']], ranges: ['*']);
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Ip([]);
     }

--- a/tests/Rule/JsonHandlerTest.php
+++ b/tests/Rule/JsonHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Json;
 use Yiisoft\Validator\Rule\JsonHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class JsonHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/JsonTest.php
+++ b/tests/Rule/JsonTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Json;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class JsonTest extends AbstractRuleTest
 {
@@ -25,7 +25,7 @@ final class JsonTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Json();
     }

--- a/tests/Rule/LessThanHandlerTest.php
+++ b/tests/Rule/LessThanHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\CompareHandler;
 use Yiisoft\Validator\Rule\LessThan;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class LessThanHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/LessThanOrEqualHandlerTest.php
+++ b/tests/Rule/LessThanOrEqualHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\CompareHandler;
 use Yiisoft\Validator\Rule\LessThanOrEqual;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class LessThanOrEqualHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/LessThanOrEqualTest.php
+++ b/tests/Rule/LessThanOrEqualTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\LessThanOrEqual;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class LessThanOrEqualTest extends AbstractRuleTest
 {
@@ -118,7 +118,7 @@ final class LessThanOrEqualTest extends AbstractRuleTest
         $rule = new LessThanOrEqual();
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new LessThanOrEqual(1);
     }

--- a/tests/Rule/LessThanTest.php
+++ b/tests/Rule/LessThanTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\LessThan;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class LessThanTest extends AbstractRuleTest
 {
@@ -118,7 +118,7 @@ final class LessThanTest extends AbstractRuleTest
         $rule = new LessThan();
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new LessThan(1);
     }

--- a/tests/Rule/NestedHandlerTest.php
+++ b/tests/Rule/NestedHandlerTest.php
@@ -12,7 +12,7 @@ use Yiisoft\Validator\Rule\NestedHandler;
 use Yiisoft\Validator\Rule\Number;
 use Yiisoft\Validator\Rule\Regex;
 use Yiisoft\Validator\Rule\Required;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class NestedHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use stdClass;
 use Yiisoft\Validator\Rule\Nested;
 use Yiisoft\Validator\Rule\Number;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\Tests\Stub\Rule;
 
 final class NestedTest extends AbstractRuleTest
@@ -107,7 +107,7 @@ final class NestedTest extends AbstractRuleTest
         new Nested(['path.to.value' => (new stdClass())]);
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Nested([new Rule('rule-name', ['key' => 'value'])]);
     }

--- a/tests/Rule/NotEqualHandlerTest.php
+++ b/tests/Rule/NotEqualHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\CompareHandler;
 use Yiisoft\Validator\Rule\NotEqual;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class NotEqualHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/NotEqualTest.php
+++ b/tests/Rule/NotEqualTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\NotEqual;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class NotEqualTest extends AbstractRuleTest
 {
@@ -175,7 +175,7 @@ final class NotEqualTest extends AbstractRuleTest
         $rule = new NotEqual();
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new NotEqual(1);
     }

--- a/tests/Rule/NumberHandlerTest.php
+++ b/tests/Rule/NumberHandlerTest.php
@@ -8,7 +8,7 @@ use stdClass;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Number;
 use Yiisoft\Validator\Rule\NumberHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class NumberHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/NumberTest.php
+++ b/tests/Rule/NumberTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Number;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class NumberTest extends AbstractRuleTest
 {
@@ -130,7 +130,7 @@ final class NumberTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Number();
     }

--- a/tests/Rule/RegexHandlerTest.php
+++ b/tests/Rule/RegexHandlerTest.php
@@ -8,7 +8,7 @@ use stdClass;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Regex;
 use Yiisoft\Validator\Rule\RegexHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class RegexHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/RegexTest.php
+++ b/tests/Rule/RegexTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Regex;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class RegexTest extends AbstractRuleTest
 {
@@ -45,7 +45,7 @@ final class RegexTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Regex('//');
     }

--- a/tests/Rule/RequiredHandlerTest.php
+++ b/tests/Rule/RequiredHandlerTest.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 use Yiisoft\Validator\Error;
 use Yiisoft\Validator\Rule\Required;
 use Yiisoft\Validator\Rule\RequiredHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 final class RequiredHandlerTest extends AbstractRuleValidatorTest
 {

--- a/tests/Rule/RequiredTest.php
+++ b/tests/Rule/RequiredTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Required;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class RequiredTest extends AbstractRuleTest
 {
@@ -25,7 +25,7 @@ final class RequiredTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Required();
     }

--- a/tests/Rule/SubsetHandlerTest.php
+++ b/tests/Rule/SubsetHandlerTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 
 use ArrayObject;
 use Yiisoft\Validator\Error;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\Rule\Subset;
 use Yiisoft\Validator\Rule\SubsetHandler;
 

--- a/tests/Rule/SubsetTest.php
+++ b/tests/Rule/SubsetTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Subset;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
 final class SubsetTest extends AbstractRuleTest
 {
@@ -30,7 +30,7 @@ final class SubsetTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Subset([]);
     }

--- a/tests/Rule/UrlHandlerTest.php
+++ b/tests/Rule/UrlHandlerTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Validator\Tests\Rule;
 
 use RuntimeException;
 use Yiisoft\Validator\Error;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\Rule\Url;
 use Yiisoft\Validator\Rule\UrlHandler;
 use Yiisoft\Validator\Tests\FunctionExists;

--- a/tests/Rule/UrlTest.php
+++ b/tests/Rule/UrlTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule;
 
 use Yiisoft\Validator\Rule\Url;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\Tests\FunctionExists;
 
 final class UrlTest extends AbstractRuleTest
@@ -74,7 +74,7 @@ final class UrlTest extends AbstractRuleTest
         ];
     }
 
-    protected function getRule(): ParametrizedRuleInterface
+    protected function getRule(): SerializableRuleInterface
     {
         return new Url();
     }

--- a/tests/RuleHandlerContainerTest.php
+++ b/tests/RuleHandlerContainerTest.php
@@ -10,7 +10,7 @@ use Yiisoft\Validator\Exception\RuleHandlerInterfaceNotImplementedException;
 use Yiisoft\Validator\Exception\RuleHandlerNotFoundException;
 use Yiisoft\Validator\RuleHandlerContainer;
 use Yiisoft\Validator\Tests\Stub\PiHandler;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 
 class RuleHandlerContainerTest extends TestCase
 {

--- a/tests/Stub/PiHandler.php
+++ b/tests/Stub/PiHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Stub;
 
 use Yiisoft\Validator\Result;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 final class PiHandler implements RuleHandlerInterface

--- a/tests/Stub/Rule.php
+++ b/tests/Stub/Rule.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Stub;
 
 use Yiisoft\Validator\Rule\Trait\HandlerClassNameTrait;
-use Yiisoft\Validator\ParametrizedRuleInterface;
+use Yiisoft\Validator\SerializableRuleInterface;
 
-final class Rule implements ParametrizedRuleInterface
+final class Rule implements SerializableRuleInterface
 {
     use HandlerClassNameTrait;
 

--- a/tests/Stub/RuleHandler.php
+++ b/tests/Stub/RuleHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Stub;
 
 use Yiisoft\Validator\Result;
-use Yiisoft\Validator\Rule\RuleHandlerInterface;
+use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 final class RuleHandler implements RuleHandlerInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #172 


What's done:

1. Rename `ParametrizedRuleInterface` -> `SerializableRuleInterface`.
2. Move `RuleHandlerInterface` one level up.
