### PR TITLE
Add annotation for return value of Rule::getOptions()

### DIFF
--- a/src/Rule/Ip.php
+++ b/src/Rule/Ip.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Validator\Rule;
 
 use Attribute;
 use Closure;
+use JetBrains\PhpStorm\ArrayShape;
 use RuntimeException;
 use Yiisoft\NetworkUtilities\IpHelper;
 use Yiisoft\Validator\SerializableRuleInterface;
@@ -402,6 +403,24 @@ final class Ip implements SerializableRuleInterface, BeforeValidationInterface
         ) . ')?(?<ipCidr>(?<ip>(?:' . IpHelper::IPV4_PATTERN . ')|(?:' . IpHelper::IPV6_PATTERN . '))(?:\/(?<cidr>-?\d+))?)$/';
     }
 
+    #[ArrayShape([
+        'networks'              => 'array',
+        'allowIpv4'             => 'bool',
+        'allowIpv6'             => 'bool',
+        'allowSubnet'           => 'bool',
+        'requireSubnet'         => 'bool',
+        'allowNegation'         => 'bool',
+        'message'               => 'string[]',
+        'ipv4NotAllowedMessage' => 'string[]',
+        'ipv6NotAllowedMessage' => 'string[]',
+        'wrongCidrMessage'      => 'string[]',
+        'noSubnetMessage'       => 'string[]',
+        'hasSubnetMessage'      => 'string[]',
+        'notInRangeMessage'     => 'string[]',
+        'ranges'                => 'array',
+        'skipOnEmpty'           => 'bool',
+        'skipOnError'           => 'bool',
+    ])]
     public function getOptions(): array
     {
         return [

--- a/src/Rule/Ip.php
+++ b/src/Rule/Ip.php
@@ -404,22 +404,22 @@ final class Ip implements SerializableRuleInterface, BeforeValidationInterface
     }
 
     #[ArrayShape([
-        'networks'              => 'array',
-        'allowIpv4'             => 'bool',
-        'allowIpv6'             => 'bool',
-        'allowSubnet'           => 'bool',
-        'requireSubnet'         => 'bool',
-        'allowNegation'         => 'bool',
-        'message'               => 'string[]',
+        'networks' => 'array',
+        'allowIpv4' => 'bool',
+        'allowIpv6' => 'bool',
+        'allowSubnet' => 'bool',
+        'requireSubnet' => 'bool',
+        'allowNegation' => 'bool',
+        'message' => 'string[]',
         'ipv4NotAllowedMessage' => 'string[]',
         'ipv6NotAllowedMessage' => 'string[]',
-        'wrongCidrMessage'      => 'string[]',
-        'noSubnetMessage'       => 'string[]',
-        'hasSubnetMessage'      => 'string[]',
-        'notInRangeMessage'     => 'string[]',
-        'ranges'                => 'array',
-        'skipOnEmpty'           => 'bool',
-        'skipOnError'           => 'bool',
+        'wrongCidrMessage' => 'string[]',
+        'noSubnetMessage' => 'string[]',
+        'hasSubnetMessage' => 'string[]',
+        'notInRangeMessage' => 'string[]',
+        'ranges' => 'array',
+        'skipOnEmpty' => 'bool',
+        'skipOnError' => 'bool',
     ])]
     public function getOptions(): array
     {

--- a/src/Rule/Number.php
+++ b/src/Rule/Number.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Validator\Rule;
 
 use Attribute;
 use Closure;
+use JetBrains\PhpStorm\ArrayShape;
 use Yiisoft\Validator\SerializableRuleInterface;
 use Yiisoft\Validator\BeforeValidationInterface;
 use Yiisoft\Validator\Rule\Trait\BeforeValidationTrait;
@@ -129,6 +130,18 @@ final class Number implements SerializableRuleInterface, BeforeValidationInterfa
         return $this->asInteger ? 'Value must be an integer.' : 'Value must be a number.';
     }
 
+    #[ArrayShape([
+        'asInteger'         => 'bool',
+        'min'               => 'float|int|null',
+        'max'               => 'float|int|null',
+        'notANumberMessage' => 'string[]',
+        'tooSmallMessage'   => 'array',
+        'tooBigMessage'     => 'array',
+        'skipOnEmpty'       => 'bool',
+        'skipOnError'       => 'bool',
+        'integerPattern'    => 'string',
+        'numberPattern'     => 'string',
+    ])]
     public function getOptions(): array
     {
         return [

--- a/src/Rule/Number.php
+++ b/src/Rule/Number.php
@@ -131,16 +131,16 @@ final class Number implements SerializableRuleInterface, BeforeValidationInterfa
     }
 
     #[ArrayShape([
-        'asInteger'         => 'bool',
-        'min'               => 'float|int|null',
-        'max'               => 'float|int|null',
+        'asInteger' => 'bool',
+        'min' => 'float|int|null',
+        'max' => 'float|int|null',
         'notANumberMessage' => 'string[]',
-        'tooSmallMessage'   => 'array',
-        'tooBigMessage'     => 'array',
-        'skipOnEmpty'       => 'bool',
-        'skipOnError'       => 'bool',
-        'integerPattern'    => 'string',
-        'numberPattern'     => 'string',
+        'tooSmallMessage' => 'array',
+        'tooBigMessage' => 'array',
+        'skipOnEmpty' => 'bool',
+        'skipOnError' => 'bool',
+        'integerPattern' => 'string',
+        'numberPattern' => 'string',
     ])]
     public function getOptions(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #225

I didn't add annotation for this

```php
public function getOptions(): array
{
    $arrayOfRules = [];
    foreach ($this->rules as $rule) {
        if ($rule instanceof SerializableRuleInterface) {
            $arrayOfRules[] = array_merge([$rule->getName()], $rule->getOptions());
        } else {
            $arrayOfRules[] = [$rule->getName()];
        }
    }
    return $arrayOfRules;
}
```