### PR TITLE
ComposerRequireChecker config: use extensions instead of whitelist

### DIFF
--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -31,3 +31,4 @@ jobs:
         ['ubuntu-latest']
       php: >-
         ['8.0', '8.1']
+      config: ./composer-require-checker.json

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,7 +1,5 @@
 {
-    "symbol-whitelist": [
-        "idn_to_ascii"
-    ],
+    "symbol-whitelist": [],
     "php-core-extensions": [
         "Core",
         "date",
@@ -10,7 +8,8 @@
         "Phar",
         "Reflection",
         "SPL",
-        "standard"
+        "standard",
+        "intl"
     ],
     "scan-files": []
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | And addition to #346.

A @vjik's suggestion taken from https://github.com/yiisoft/translator/pull/71.
