### PR TITLE
Revert support object and class string as `$rules` in `Validator::validate()`

### DIFF
--- a/src/Helper/RulesNormalizer.php
+++ b/src/Helper/RulesNormalizer.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Helper;
 
 use InvalidArgumentException;
+use ReflectionException;
 use Yiisoft\Validator\Rule\Callback;
 use Yiisoft\Validator\RuleInterface;
+use Yiisoft\Validator\RulesProvider\AttributesRulesProvider;
 use Yiisoft\Validator\RulesProviderInterface;
 use Yiisoft\Validator\SkipOnEmptyInterface;
 use Yiisoft\Validator\ValidatorInterface;
@@ -24,11 +26,12 @@ final class RulesNormalizer
      * @psalm-param RulesType $rules
      *
      * @throws InvalidArgumentException
+     * @throws ReflectionException
      *
      * @return iterable<int|string, iterable<int|string, RuleInterface>>
      */
     public static function normalize(
-        iterable|object|callable|null $rules,
+        callable|iterable|object|string|null $rules,
         mixed $data = null,
         ?callable $defaultSkipOnEmptyCriteria = null,
     ): iterable {
@@ -62,10 +65,10 @@ final class RulesNormalizer
     /**
      * @psalm-param RulesType $rules
      *
-     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     private static function prepareRulesArray(
-        iterable|object|callable|null $rules,
+        callable|iterable|object|string|null $rules,
         mixed $data,
     ): iterable {
         if ($rules === null) {
@@ -82,12 +85,11 @@ final class RulesNormalizer
             return [$rules];
         }
 
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
         if (is_iterable($rules)) {
             return $rules;
         }
 
-        throw new InvalidArgumentException('A rules object must implement RulesProviderInterface or RuleInterface.');
+        return (new AttributesRulesProvider($rules))->getRules();
     }
 
     /**

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator;
 
 use InvalidArgumentException;
+use ReflectionException;
 use Yiisoft\Translator\CategorySource;
 use Yiisoft\Translator\IdMessageReader;
 use Yiisoft\Translator\IntlMessageFormatter;
@@ -53,10 +54,11 @@ final class Validator implements ValidatorInterface
      * @psalm-param RulesType $rules
      *
      * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     public function validate(
         mixed $data,
-        iterable|object|callable|null $rules = null,
+        callable|iterable|object|string|null $rules = null,
         ?ValidationContext $context = null
     ): Result {
         $data = DataSetNormalizer::normalize($data);

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -17,7 +17,7 @@ interface ValidatorInterface
      * @param DataSetInterface|mixed|RulesProviderInterface $data Data set to validate. If {@see RulesProviderInterface}
      * instance provided and rules are not specified explicitly, they are read from the
      * {@see RulesProviderInterface::getRules()}.
-     * @param callable|iterable|object|string|null $rules Rules to apply. If specified, rules are not read from data set 
+     * @param callable|iterable|object|string|null $rules Rules to apply. If specified, rules are not read from data set
      * even if it is an instance of {@see RulesProviderInterface}.
      * @param ValidationContext|null $context Validation context that may take into account when performing validation.
      *

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -17,8 +17,8 @@ interface ValidatorInterface
      * @param DataSetInterface|mixed|RulesProviderInterface $data Data set to validate. If {@see RulesProviderInterface}
      * instance provided and rules are not specified explicitly, they are read from the
      * {@see RulesProviderInterface::getRules()}.
-     * @param callable|iterable|object|string|null $rules Rules to apply. If specified, rules are not read from data set even if it is
-     * an instance of {@see RulesProviderInterface}.
+     * @param callable|iterable|object|string|null $rules Rules to apply. If specified, rules are not read from data set 
+     * even if it is an instance of {@see RulesProviderInterface}.
      * @param ValidationContext|null $context Validation context that may take into account when performing validation.
      *
      * @psalm-param RulesType $rules

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Validator;
 /**
  * Validator validates {@link DataSetInterface} against rules set for data set attributes.
  *
- * @psalm-type RulesType = null|RuleInterface|RulesProviderInterface|callable|iterable<RuleInterface|RuleInterface[]|callable|callable[]>
+ * @psalm-type RulesType = null|class-string|object|callable|iterable<RuleInterface|RuleInterface[]|callable|callable[]>
  */
 interface ValidatorInterface
 {
@@ -17,7 +17,7 @@ interface ValidatorInterface
      * @param DataSetInterface|mixed|RulesProviderInterface $data Data set to validate. If {@see RulesProviderInterface}
      * instance provided and rules are not specified explicitly, they are read from the
      * {@see RulesProviderInterface::getRules()}.
-     * @param callable|iterable|object|null $rules Rules to apply. If specified, rules are not read from data set even if it is
+     * @param callable|iterable|object|string|null $rules Rules to apply. If specified, rules are not read from data set even if it is
      * an instance of {@see RulesProviderInterface}.
      * @param ValidationContext|null $context Validation context that may take into account when performing validation.
      *
@@ -25,7 +25,7 @@ interface ValidatorInterface
      */
     public function validate(
         mixed $data,
-        iterable|object|callable|null $rules = null,
+        callable|iterable|object|string|null $rules = null,
         ?ValidationContext $context = null
     ): Result;
 }

--- a/tests/Helper/RulesNormalizerTest.php
+++ b/tests/Helper/RulesNormalizerTest.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Yiisoft\Validator\Tests\Helper;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Yiisoft\Validator\Helper\RulesNormalizer;
+use Yiisoft\Validator\Tests\Support\Data\ObjectWithDifferentPropertyVisibility;
 
 final class RulesNormalizerTest extends TestCase
 {
@@ -15,6 +14,22 @@ final class RulesNormalizerTest extends TestCase
     {
         return [
             'null' => [[], null],
+            'object' => [
+                [
+                    'name' => ['required'],
+                    'age' => ['number'],
+                    'number' => ['number'],
+                ],
+                new ObjectWithDifferentPropertyVisibility(),
+            ],
+            'class-string' => [
+                [
+                    'name' => ['required'],
+                    'age' => ['number'],
+                    'number' => ['number'],
+                ],
+                ObjectWithDifferentPropertyVisibility::class,
+            ],
         ];
     }
 
@@ -32,7 +47,7 @@ final class RulesNormalizerTest extends TestCase
      */
     public function testNormalizeWithArrayResult(
         array $expected,
-        iterable|object|null $rules,
+        callable|iterable|object|string|null $rules,
         mixed $data = null
     ): void {
         $rules = RulesNormalizer::normalize($rules, $data);
@@ -46,12 +61,5 @@ final class RulesNormalizerTest extends TestCase
         }
 
         $this->assertSame($expected, $result);
-    }
-
-    public function testInvalidRules(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('A rules object must implement RulesProviderInterface or RuleInterface.');
-        RulesNormalizer::normalize(new stdClass());
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1211,7 +1211,7 @@ class ValidatorTest extends TestCase
 
             public function validate(
                 mixed $data,
-                iterable|object|callable|null $rules = null,
+                callable|iterable|object|string|null $rules = null,
                 ?ValidationContext $context = null
             ): Result {
                 $dataSet = DataSetNormalizer::normalize($data);
@@ -1252,6 +1252,20 @@ class ValidatorTest extends TestCase
         $message = 'Rule should be either an instance of Yiisoft\Validator\RuleInterface or a callable, int given.';
         $this->expectExceptionMessage($message);
         $validator->validate([], [new Boolean(), 1]);
+    }
+
+    public function testRulesAsObjectNameWithRuleAttributes(): void
+    {
+        $validator = ValidatorFactory::make();
+        $result = $validator->validate(['name' => 'Test name'], ObjectWithAttributesOnly::class);
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testRulesAsObjectWithRuleAttributes(): void
+    {
+        $validator = ValidatorFactory::make();
+        $result = $validator->validate(['name' => 'Test name'], new ObjectWithAttributesOnly());
+        $this->assertTrue($result->isValid());
     }
 
     public function testDataWithPostValidationHook(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -
