### PR TITLE
Fix propagate options in `Nested` rule when rules are null

### DIFF
--- a/src/Rule/Nested.php
+++ b/src/Rule/Nested.php
@@ -273,11 +273,13 @@ final class Nested implements
 
     public function propagateOptions(): void
     {
+        if ($this->rules === null) {
+            return;
+        }
+
         $rules = [];
+
         /**
-         * @psalm-suppress PossiblyNullIterator Rules can't be null at this point because of the order and check with
-         * early return in {@see prepareRules()}.
-         *
          * @var int|string $attributeRulesIndex Index is either integer or string because of the array conversion in
          * {@see ensureArrayHasRules()}.
          * @var RuleInterface[] $attributeRules Conversion to array is done in {@see ensureArrayHasRules()}.

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -1203,7 +1203,7 @@ final class NestedTest extends RuleTestCase
     {
        $rule = new Nested(null);
        $rule->propagateOptions();
-       $this->expectNotToPerformAssertions();
+       $this->assertNull($rule->getRules());
     }
 
     protected function getDifferentRuleInHandlerItems(): array

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -1201,9 +1201,9 @@ final class NestedTest extends RuleTestCase
 
     public function testPropagateOptionsWithNullRules(): void
     {
-       $rule = new Nested(null);
-       $rule->propagateOptions();
-       $this->assertNull($rule->getRules());
+        $rule = new Nested(null);
+        $rule->propagateOptions();
+        $this->assertNull($rule->getRules());
     }
 
     protected function getDifferentRuleInHandlerItems(): array

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -1199,6 +1199,13 @@ final class NestedTest extends RuleTestCase
         new Nested(new Required());
     }
 
+    public function testPropagateOptionsWithNullRules(): void
+    {
+       $rule = new Nested(null);
+       $rule->propagateOptions();
+       $this->expectNotToPerformAssertions();
+    }
+
     protected function getDifferentRuleInHandlerItems(): array
     {
         return [Nested::class, NestedHandler::class];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
