### PR TITLE
Improve validation context

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,7 +828,7 @@ final class CompanyNameHandler implements Rule\RuleHandlerInterface
         
         $result = new Result();
         $dataSet = $context->getDataSet();
-        $hasCompany = $dataSet !== null && $dataSet->getAttributeValue('hasCompany') === true;
+        $hasCompany = $dataSet->getAttributeValue('hasCompany') === true;
 
         if ($hasCompany && $this->isCompanyNameValid($value) === false) {
             $result->addError('Company name is not valid.');

--- a/src/Rule/CompareHandler.php
+++ b/src/Rule/CompareHandler.php
@@ -43,7 +43,7 @@ final class CompareHandler implements RuleHandlerInterface
 
         if ($targetValue === null && $targetAttribute !== null) {
             /** @var mixed $targetValue */
-            $targetValue = $context->getDataSet()?->getAttributeValue($targetAttribute);
+            $targetValue = $context->getDataSet()->getAttributeValue($targetAttribute);
             if (!is_scalar($targetValue)) {
                 return $result->addError($rule->getIncorrectDataSetTypeMessage(), [
                     'type' => get_debug_type($targetValue),

--- a/src/ValidationContext.php
+++ b/src/ValidationContext.php
@@ -82,7 +82,6 @@ final class ValidationContext
     public function getRawData(): mixed
     {
         $this->checkValidatorAndRawData();
-
         return $this->rawData;
     }
 
@@ -139,9 +138,10 @@ final class ValidationContext
         return ArrayHelper::getValue($this->parameters, $key, $default);
     }
 
-    public function setParameter(string $key, mixed $value): void
+    public function setParameter(string $key, mixed $value): self
     {
         $this->parameters[$key] = $value;
+        return $this;
     }
 
     public function isAttributeMissing(): bool

--- a/src/ValidationContext.php
+++ b/src/ValidationContext.php
@@ -91,14 +91,6 @@ final class ValidationContext
     }
 
     /**
-     * @return array Arbitrary parameters.
-     */
-    public function getParameters(): array
-    {
-        return $this->parameters;
-    }
-
-    /**
      * Get named parameter.
      *
      * @param string $key Parameter name.

--- a/src/ValidationContext.php
+++ b/src/ValidationContext.php
@@ -21,14 +21,17 @@ final class ValidationContext
     private ?DataSetInterface $dataSet = null;
 
     /**
+     * @var string|null Validated attribute name. Null if a single value is validated.
+     */
+    private ?string $attribute = null;
+
+    /**
      * @param mixed $rawData The raw validated data.
-     * @param string|null $attribute Validated attribute name. Null if a single value is validated.
      * @param array $parameters Arbitrary parameters.
      */
     public function __construct(
         private ValidatorInterface $validator,
         private mixed $rawData,
-        private ?string $attribute = null,
         private array $parameters = []
     ) {
     }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -68,16 +68,17 @@ final class Validator implements ValidatorInterface
             $this->defaultSkipOnEmptyCriteria
         );
 
-        $compoundResult = new Result();
-        $context ??= new ValidationContext($this, $data, $dataSet);
-        $results = [];
+        $context ??= new ValidationContext($this, $data);
+        $context->setDataSet($dataSet);
 
+        $results = [];
         foreach ($rules as $attribute => $attributeRules) {
             $result = new Result();
 
             if (is_int($attribute)) {
                 /** @psalm-suppress MixedAssignment */
                 $validatedData = $dataSet->getData();
+                $context->setAttribute(null);
             } else {
                 /** @psalm-suppress MixedAssignment */
                 $validatedData = $dataSet->getAttributeValue($attribute);
@@ -92,6 +93,8 @@ final class Validator implements ValidatorInterface
 
             $results[] = $result;
         }
+
+        $compoundResult = new Result();
 
         foreach ($results as $result) {
             foreach ($result->getErrors() as $error) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -68,8 +68,10 @@ final class Validator implements ValidatorInterface
             $this->defaultSkipOnEmptyCriteria
         );
 
-        $context ??= new ValidationContext($this, $data);
-        $context->setDataSet($dataSet);
+        $context ??= new ValidationContext();
+        $context
+            ->setValidatorAndRawDataOnce($this, $data)
+            ->setDataSet($dataSet);
 
         $results = [];
         foreach ($rules as $attribute => $attributeRules) {

--- a/tests/Rule/CallbackTest.php
+++ b/tests/Rule/CallbackTest.php
@@ -178,7 +178,7 @@ final class CallbackTest extends RuleTestCase
                         RuleInterface $rule,
                         ValidationContext $context
                     ): Result {
-                        if ($value !== $context->getDataSet()?->getAttributeValue('age')) {
+                        if ($value !== $context->getDataSet()->getAttributeValue('age')) {
                             throw new RuntimeException('Method scope was not bound to the object.');
                         }
 

--- a/tests/Rule/LimitHandlerTraitTest.php
+++ b/tests/Rule/LimitHandlerTraitTest.php
@@ -12,7 +12,6 @@ use Yiisoft\Validator\Rule\Trait\LimitHandlerTrait;
 use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\RuleInterface;
 use Yiisoft\Validator\Tests\Support\Rule\RuleWithoutOptions;
-use Yiisoft\Validator\Tests\Support\ValidatorFactory;
 use Yiisoft\Validator\ValidationContext;
 
 final class LimitHandlerTraitTest extends TestCase
@@ -81,7 +80,7 @@ final class LimitHandlerTraitTest extends TestCase
                 $this->validateLimits($rule, $context, $number, $result);
             }
         };
-        $context = new ValidationContext(ValidatorFactory::make(), null);
+        $context = new ValidationContext();
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('$rule must implement both LimitInterface and RuleInterface.');

--- a/tests/ValidationContextTest.php
+++ b/tests/ValidationContextTest.php
@@ -64,7 +64,7 @@ final class ValidationContextTest extends TestCase
         $context->validate(42);
     }
 
-    public function tesGetRawDataWithoutRawData(): void
+    public function testGetRawDataWithoutRawData(): void
     {
         $context = new ValidationContext();
 

--- a/tests/ValidationContextTest.php
+++ b/tests/ValidationContextTest.php
@@ -20,7 +20,6 @@ final class ValidationContextTest extends TestCase
         $this->assertSame(7, $context->getRawData());
         $this->assertNull($context->getDataSet());
         $this->assertNull($context->getAttribute());
-        $this->assertSame([], $context->getParameters());
     }
 
     public function testConstructor(): void
@@ -33,7 +32,7 @@ final class ValidationContextTest extends TestCase
         $this->assertSame($data, $context->getRawData());
         $this->assertSame($dataSet, $context->getDataSet());
         $this->assertSame('name', $context->getAttribute());
-        $this->assertSame(['key' => 42], $context->getParameters());
+        $this->assertSame(42, $context->getParameter('key'));
     }
 
     public function testSetParameter(): void
@@ -41,7 +40,7 @@ final class ValidationContextTest extends TestCase
         $context = new ValidationContext(ValidatorFactory::make(), null);
         $context->setParameter('key', 42);
 
-        $this->assertSame(['key' => 42], $context->getParameters());
+        $this->assertSame(42, $context->getParameter('key'));
     }
 
     public function testGetParameter(): void

--- a/tests/ValidationContextTest.php
+++ b/tests/ValidationContextTest.php
@@ -8,21 +8,12 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Yiisoft\Validator\DataSet\ArrayDataSet;
 use Yiisoft\Validator\ValidationContext;
-use Yiisoft\Validator\Validator;
 
 final class ValidationContextTest extends TestCase
 {
-    public function testDefault(): void
-    {
-        $context = new ValidationContext(new Validator(), 7);
-
-        $this->assertSame(7, $context->getRawData());
-        $this->assertNull($context->getAttribute());
-    }
-
     public function testGetDataSetWithoutDataSet(): void
     {
-        $context = new ValidationContext(new Validator(), 7);
+        $context = new ValidationContext();
 
         $this->expectException(RuntimeException::class);
         $this->expectErrorMessage('Data set in validation context is not set.');
@@ -31,11 +22,8 @@ final class ValidationContextTest extends TestCase
 
     public function testConstructor(): void
     {
-        $data = ['x' => 7];
+        $context = new ValidationContext(['key' => 42]);
 
-        $context = new ValidationContext(new Validator(), $data, ['key' => 42]);
-
-        $this->assertSame($data, $context->getRawData());
         $this->assertSame(42, $context->getParameter('key'));
     }
 
@@ -43,7 +31,7 @@ final class ValidationContextTest extends TestCase
     {
         $dataSet = new ArrayDataSet();
 
-        $context = new ValidationContext(new Validator(), null);
+        $context = new ValidationContext();
         $context->setDataSet($dataSet);
 
         $this->assertSame($dataSet, $context->getDataSet());
@@ -51,7 +39,7 @@ final class ValidationContextTest extends TestCase
 
     public function testSetParameter(): void
     {
-        $context = new ValidationContext(new Validator(), null);
+        $context = new ValidationContext();
         $context->setParameter('key', 42);
 
         $this->assertSame(42, $context->getParameter('key'));
@@ -59,10 +47,28 @@ final class ValidationContextTest extends TestCase
 
     public function testGetParameter(): void
     {
-        $context = new ValidationContext(new Validator(), null, parameters: ['key' => 42]);
+        $context = new ValidationContext(['key' => 42]);
 
         $this->assertSame(42, $context->getParameter('key'));
         $this->assertNull($context->getParameter('non-exists'));
         $this->assertSame(7, $context->getParameter('non-exists', 7));
+    }
+
+    public function testValidateWithoutValidator(): void
+    {
+        $context = new ValidationContext();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectErrorMessage('Validator and raw data in validation context is not set.');
+        $context->validate(42);
+    }
+
+    public function tesGetRawDataWithoutRawData(): void
+    {
+        $context = new ValidationContext();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectErrorMessage('Validator and raw data in validation context is not set.');
+        $context->getRawData();
     }
 }

--- a/tests/ValidationContextTest.php
+++ b/tests/ValidationContextTest.php
@@ -5,39 +5,54 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Yiisoft\Validator\DataSet\ArrayDataSet;
-use Yiisoft\Validator\Tests\Support\ValidatorFactory;
 use Yiisoft\Validator\ValidationContext;
+use Yiisoft\Validator\Validator;
 
 final class ValidationContextTest extends TestCase
 {
     public function testDefault(): void
     {
-        $validator = ValidatorFactory::make();
-
-        $context = new ValidationContext($validator, 7);
+        $context = new ValidationContext(new Validator(), 7);
 
         $this->assertSame(7, $context->getRawData());
-        $this->assertNull($context->getDataSet());
         $this->assertNull($context->getAttribute());
+    }
+
+    public function testGetDataSetWithoutDataSet(): void
+    {
+        $context = new ValidationContext(new Validator(), 7);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectErrorMessage('Data set in validation context is not set.');
+        $context->getDataSet();
     }
 
     public function testConstructor(): void
     {
         $data = ['x' => 7];
-        $dataSet = new ArrayDataSet();
 
-        $context = new ValidationContext(ValidatorFactory::make(), $data, $dataSet, 'name', ['key' => 42]);
+        $context = new ValidationContext(new Validator(), $data, 'name', ['key' => 42]);
 
         $this->assertSame($data, $context->getRawData());
-        $this->assertSame($dataSet, $context->getDataSet());
         $this->assertSame('name', $context->getAttribute());
         $this->assertSame(42, $context->getParameter('key'));
     }
 
+    public function testDataSet(): void
+    {
+        $dataSet = new ArrayDataSet();
+
+        $context = new ValidationContext(new Validator(), null);
+        $context->setDataSet($dataSet);
+
+        $this->assertSame($dataSet, $context->getDataSet());
+    }
+
     public function testSetParameter(): void
     {
-        $context = new ValidationContext(ValidatorFactory::make(), null);
+        $context = new ValidationContext(new Validator(), null);
         $context->setParameter('key', 42);
 
         $this->assertSame(42, $context->getParameter('key'));
@@ -45,7 +60,7 @@ final class ValidationContextTest extends TestCase
 
     public function testGetParameter(): void
     {
-        $context = new ValidationContext(ValidatorFactory::make(), null, parameters: ['key' => 42]);
+        $context = new ValidationContext(new Validator(), null, parameters: ['key' => 42]);
 
         $this->assertSame(42, $context->getParameter('key'));
         $this->assertNull($context->getParameter('non-exists'));

--- a/tests/ValidationContextTest.php
+++ b/tests/ValidationContextTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Yiisoft\Validator\DataSet\ArrayDataSet;
 use Yiisoft\Validator\ValidationContext;
+use Yiisoft\Validator\Validator;
 
 final class ValidationContextTest extends TestCase
 {
@@ -70,5 +71,18 @@ final class ValidationContextTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectErrorMessage('Validator and raw data in validation context is not set.');
         $context->getRawData();
+    }
+
+    public function testSetValidatorAndRawDataOnce(): void
+    {
+        $validator = new Validator();
+
+        $context = new ValidationContext();
+
+        $context
+            ->setValidatorAndRawDataOnce($validator, 1)
+            ->setValidatorAndRawDataOnce($validator, 2);
+
+        $this->assertSame(1, $context->getRawData());
     }
 }

--- a/tests/ValidationContextTest.php
+++ b/tests/ValidationContextTest.php
@@ -33,10 +33,9 @@ final class ValidationContextTest extends TestCase
     {
         $data = ['x' => 7];
 
-        $context = new ValidationContext(new Validator(), $data, 'name', ['key' => 42]);
+        $context = new ValidationContext(new Validator(), $data, ['key' => 42]);
 
         $this->assertSame($data, $context->getRawData());
-        $this->assertSame('name', $context->getAttribute());
         $this->assertSame(42, $context->getParameter('key'));
     }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1212,7 +1212,7 @@ class ValidatorTest extends TestCase
                 callable|iterable|object|string|null $rules = null,
                 ?ValidationContext $context = null
             ): Result {
-                $context ??= new ValidationContext($this, $data);
+                $context ??= new ValidationContext();
 
                 $result = $this->validator->validate($data, $rules, $context);
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1212,8 +1212,7 @@ class ValidatorTest extends TestCase
                 callable|iterable|object|string|null $rules = null,
                 ?ValidationContext $context = null
             ): Result {
-                $dataSet = DataSetNormalizer::normalize($data);
-                $context ??= new ValidationContext($this, $data, $dataSet);
+                $context ??= new ValidationContext($this, $data);
 
                 $result = $this->validator->validate($data, $rules, $context);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -

- Remove `getParameters()` method
- Make `setParameter()` fluent
- Move arguments from constructor to separate methods:
  - validator and raw data → `setValidatorAndRawDataOnce()`
  - data set → `setDataSet()`
- Remove attribute from constructor

It's allow send to validator custom parameters via context:

```php
$validator->validate(
    $data,
    $rules,
    new ValidationContext(['a' => 7, 'b' => 42])
)
```
