### PR TITLE
Change order of `Count` constructor parameters

### DIFF
--- a/src/Rule/Count.php
+++ b/src/Rule/Count.php
@@ -46,12 +46,12 @@ final class Count implements
     private ?object $objectValidated = null;
 
     /**
+     * @param int|null $exactly Exact number of items. `null` means no strict comparison. Mutually exclusive with
+     * {@see $min} and {@see $max}.
      * @param int|null $min Minimum number of items. null means no minimum number limit. Can't be combined with
      * {@see $exactly}. See {@see $lessThanMinMessage} for the customized message for a value with too few items.
      * @param int|null $max Maximum number of items. null means no maximum number limit. Can't be combined with
      * {@see $exactly}. See {@see $greaterThanMaxMessage} for the customized message for a value with too many items.
-     * @param int|null $exactly Exact number of items. `null` means no strict comparison. Mutually exclusive with
-     * {@see $min} and {@see $max}.
      * @param string $incorrectInputMessage Error message used when the value is neither an array nor an object
      * implementing {@see \Countable} interface.
      *
@@ -89,9 +89,9 @@ final class Count implements
      * @psalm-param WhenType $when
      */
     public function __construct(
+        int|null $exactly = null,
         int|null $min = null,
         int|null $max = null,
-        int|null $exactly = null,
         private string $incorrectInputMessage = 'This value must be an array or implement \Countable interface.',
         string $lessThanMinMessage = 'This value must contain at least {min, number} {min, plural, one{item} ' .
         'other{items}}.',

--- a/tests/Rule/Base/RuleTestCase.php
+++ b/tests/Rule/Base/RuleTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Validator\Tests\Rule\Base;
 
 use PHPUnit\Framework\TestCase;
+use Yiisoft\Validator\RuleInterface;
 use Yiisoft\Validator\Validator;
 
 abstract class RuleTestCase extends TestCase
@@ -26,7 +27,7 @@ abstract class RuleTestCase extends TestCase
     /**
      * @dataProvider dataValidationFailed
      */
-    public function testValidationFailed(mixed $data, array|null $rules, array $errorMessagesIndexedByPath): void
+    public function testValidationFailed(mixed $data, array|RuleInterface|null $rules, array $errorMessagesIndexedByPath): void
     {
         $result = (new Validator())->validate($data, $rules);
 

--- a/tests/Rule/CountTest.php
+++ b/tests/Rule/CountTest.php
@@ -121,6 +121,7 @@ final class CountTest extends RuleTestCase
                 ['data' => ['Attribute - data, type - int.']],
             ],
 
+            [[1], new Count(3), ['' => ['This value must contain exactly 3 items.']]],
             [[1], [new Count(min: 3)], ['' => [$lessThanMinmessage]]],
             [[], [new Count(min: 3)], ['' => [$lessThanMinmessage]]],
             [[0, 0], [new Count(min: 3)], ['' => [$lessThanMinmessage]]],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

With code `new Count(3)` expected that count equal to 3.