### PR TITLE
Fix Number::integerOnly option name

### DIFF
--- a/docs/guide/en/conditional-validation.md
+++ b/docs/guide/en/conditional-validation.md
@@ -153,7 +153,7 @@ An example with using `WhenNull` as parameter (note that an instance is passed, 
 use Yiisoft\Validator\Rule\Number;
 use Yiisoft\Validator\EmptyCondition\WhenNull;
 
-new Number(asInteger: true, max: 100, skipOnEmpty: new WhenNull());
+new Number(integerOnly: true, max: 100, skipOnEmpty: new WhenNull());
 ```
 
 ### Custom empty condition
@@ -172,7 +172,7 @@ final class WhenZero
     }
 }
 
-new Number(asInteger: true, max: 100, skipOnEmpty: new WhenZero());
+new Number(integerOnly: true, max: 100, skipOnEmpty: new WhenZero());
 ```
 
 or just a callable:
@@ -181,8 +181,8 @@ or just a callable:
 use Yiisoft\Validator\Rule\Number;
 
 new Number(
-    asInteger: true, 
-    max: 100, 
+    integerOnly: true,
+    max: 100,
     skipOnEmpty: static function (mixed $value, bool $isAttributeMissing): bool {
         return $isAttributeMissing || $value === 0;
     }

--- a/src/Rule/Number.php
+++ b/src/Rule/Number.php
@@ -198,7 +198,7 @@ final class Number implements RuleWithOptionsInterface, SkipOnErrorInterface, Wh
     public function getOptions(): array
     {
         return [
-            'asInteger' => $this->integerOnly,
+            'integerOnly' => $this->integerOnly,
             'min' => $this->min,
             'max' => $this->max,
             'incorrectInputMessage' => [

--- a/tests/Helper/RulesDumperTest.php
+++ b/tests/Helper/RulesDumperTest.php
@@ -36,7 +36,7 @@ final class RulesDumperTest extends TestCase
                     'attributeName' => [
                         $dump = [
                             'number',
-                            'asInteger' => true,
+                            'integerOnly' => true,
                             'min' => 10,
                             'max' => 100,
                             'incorrectInputMessage' => [

--- a/tests/Rule/CompositeTest.php
+++ b/tests/Rule/CompositeTest.php
@@ -46,7 +46,7 @@ final class CompositeTest extends RuleTestCase
                     'rules' => [
                         [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => 13,
                             'incorrectInputMessage' => [
@@ -72,7 +72,7 @@ final class CompositeTest extends RuleTestCase
                         ],
                         [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => 14,
                             'incorrectInputMessage' => [
@@ -110,7 +110,7 @@ final class CompositeTest extends RuleTestCase
                     'rules' => [
                         [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => 13,
                             'incorrectInputMessage' => [

--- a/tests/Rule/EachTest.php
+++ b/tests/Rule/EachTest.php
@@ -51,7 +51,7 @@ final class EachTest extends RuleTestCase
                     'rules' => [
                         [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => 13,
                             'incorrectInputMessage' => [
@@ -77,7 +77,7 @@ final class EachTest extends RuleTestCase
                         ],
                         [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => 14,
                             'incorrectInputMessage' => [
@@ -123,7 +123,7 @@ final class EachTest extends RuleTestCase
                     'rules' => [
                         [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => 13,
                             'incorrectInputMessage' => [

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -114,7 +114,7 @@ final class NestedTest extends RuleTestCase
                     'rules' => [
                         [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => null,
                             'incorrectInputMessage' => [
@@ -166,7 +166,7 @@ final class NestedTest extends RuleTestCase
                     'rules' => [
                         'user.age' => [
                             'number',
-                            'asInteger' => false,
+                            'integerOnly' => false,
                             'min' => null,
                             'max' => null,
                             'incorrectInputMessage' => [

--- a/tests/Rule/NumberTest.php
+++ b/tests/Rule/NumberTest.php
@@ -32,7 +32,7 @@ final class NumberTest extends RuleTestCase
             [
                 new Number(),
                 [
-                    'asInteger' => false,
+                    'integerOnly' => false,
                     'min' => null,
                     'max' => null,
                     'incorrectInputMessage' => [
@@ -60,7 +60,7 @@ final class NumberTest extends RuleTestCase
             [
                 new Number(min: 1),
                 [
-                    'asInteger' => false,
+                    'integerOnly' => false,
                     'min' => 1,
                     'max' => null,
                     'incorrectInputMessage' => [
@@ -88,7 +88,7 @@ final class NumberTest extends RuleTestCase
             [
                 new Number(max: 1),
                 [
-                    'asInteger' => false,
+                    'integerOnly' => false,
                     'min' => null,
                     'max' => 1,
                     'incorrectInputMessage' => [
@@ -116,7 +116,7 @@ final class NumberTest extends RuleTestCase
             [
                 new Number(min: 2, max: 10),
                 [
-                    'asInteger' => false,
+                    'integerOnly' => false,
                     'min' => 2,
                     'max' => 10,
                     'incorrectInputMessage' => [
@@ -144,7 +144,7 @@ final class NumberTest extends RuleTestCase
             [
                 new Number(integerOnly: true),
                 [
-                    'asInteger' => true,
+                    'integerOnly' => true,
                     'min' => null,
                     'max' => null,
                     'incorrectInputMessage' => [


### PR DESCRIPTION
property was renamed in #490, option should be renamed too.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | https://github.com/yiisoft/validator/pull/490/files#r1093804737
