### PR TITLE
`Compare` - fix mutant and bug with using `>=` and `<=` operators with floats

### DIFF
--- a/src/Rule/CompareHandler.php
+++ b/src/Rule/CompareHandler.php
@@ -12,7 +12,6 @@ use Yiisoft\Validator\RuleHandlerInterface;
 use Yiisoft\Validator\ValidationContext;
 
 use function gettype;
-use function in_array;
 
 /**
  * Compares the specified value with "target" value provided directly or within an attribute.
@@ -139,14 +138,11 @@ final class CompareHandler implements RuleHandlerInterface
      */
     private function compareValues(string $type, string $operator, mixed $value, mixed $targetValue): bool
     {
-        if (!in_array($operator, ['==', '===', '!=', '!==', '>=', '<='])) {
-            if ($type === CompareType::STRING) {
-                $value = $this->normalizeString($value);
-                $targetValue = $this->normalizeString($targetValue);
-            } elseif ($type === CompareType::NUMBER) {
-                $value = $this->normalizeNumber($value);
-                $targetValue = $this->normalizeNumber($targetValue);
-            }
+        if ($operator === '>' || $operator === '<') {
+            /** @var mixed $value */
+            $value = $this->normalizeValue($type, $value);
+            /** @var mixed $targetValue */
+            $targetValue = $this->normalizeValue($type, $targetValue);
         }
 
         return match ($operator) {
@@ -155,9 +151,11 @@ final class CompareHandler implements RuleHandlerInterface
             '!=' => !$this->checkValuesAreEqual($type, $value, $targetValue),
             '!==' => !$this->checkValuesAreEqual($type, $value, $targetValue, strict: true),
             '>' => $value > $targetValue,
-            '>=' => $this->checkValuesAreEqual($type, $value, $targetValue) || $value > $targetValue,
+            '>=' => $this->checkValuesAreEqual($type, $value, $targetValue) ||
+                $this->normalizeValue($type, $value) > $this->normalizeValue($type, $targetValue),
             '<' => $value < $targetValue,
-            '<=' => $this->checkValuesAreEqual($type, $value, $targetValue) || $value < $targetValue,
+            '<=' => $this->checkValuesAreEqual($type, $value, $targetValue) ||
+                $this->normalizeValue($type, $value) < $this->normalizeValue($type, $targetValue),
         };
     }
 
@@ -208,6 +206,24 @@ final class CompareHandler implements RuleHandlerInterface
     private function checkFloatsAreEqual(float $value, float $targetValue): bool
     {
         return abs($value - $targetValue) < PHP_FLOAT_EPSILON;
+    }
+
+    /**
+     * Normalizes compared value depending on selected {@see AbstractCompare::$type}.
+     *
+     * @param string $type The type of the values being compared ({@see AbstractCompare::$type}).
+     * @psalm-param CompareType::ORIGINAL | CompareType::STRING | CompareType::NUMBER $type
+     *
+     * @param mixed $value One of the compared values. Both validated and target value can be used.
+     * @return mixed Normalized value ready for comparison.
+     */
+    private function normalizeValue(string $type, mixed $value): mixed
+    {
+        return match ($type) {
+            CompareType::ORIGINAL => $value,
+            CompareType::STRING => $this->normalizeString($value),
+            CompareType::NUMBER => $this->normalizeNumber($value),
+        };
     }
 
     /**

--- a/src/Rule/CompareHandler.php
+++ b/src/Rule/CompareHandler.php
@@ -139,7 +139,7 @@ final class CompareHandler implements RuleHandlerInterface
      */
     private function compareValues(string $type, string $operator, mixed $value, mixed $targetValue): bool
     {
-        if (!in_array($operator, ['==', '===', '!=', '!=='])) {
+        if (!in_array($operator, ['==', '===', '!=', '!==', '>=', '<='])) {
             if ($type === CompareType::STRING) {
                 $value = $this->normalizeString($value);
                 $targetValue = $this->normalizeString($targetValue);
@@ -155,9 +155,9 @@ final class CompareHandler implements RuleHandlerInterface
             '!=' => !$this->checkValuesAreEqual($type, $value, $targetValue),
             '!==' => !$this->checkValuesAreEqual($type, $value, $targetValue, strict: true),
             '>' => $value > $targetValue,
-            '>=' => $value >= $targetValue,
+            '>=' => $this->checkValuesAreEqual($type, $value, $targetValue) || $value > $targetValue,
             '<' => $value < $targetValue,
-            '<=' => $value <= $targetValue,
+            '<=' => $this->checkValuesAreEqual($type, $value, $targetValue) || $value < $targetValue,
         };
     }
 

--- a/src/Rule/CompareHandler.php
+++ b/src/Rule/CompareHandler.php
@@ -215,6 +215,7 @@ final class CompareHandler implements RuleHandlerInterface
      * @psalm-param CompareType::ORIGINAL | CompareType::STRING | CompareType::NUMBER $type
      *
      * @param mixed $value One of the compared values. Both validated and target value can be used.
+     *
      * @return mixed Normalized value ready for comparison.
      */
     private function normalizeValue(string $type, mixed $value): mixed

--- a/tests/Rule/CompareTest.php
+++ b/tests/Rule/CompareTest.php
@@ -224,6 +224,18 @@ final class CompareTest extends RuleTestCase
                 1 - 0.83,
                 [new Compare(0.17, operator: '>=')],
             ],
+            'target value: float as expression result, value: float with the same value, type: number, operator: >=' => [
+                0.17,
+                [new Compare(1 - 0.83, operator: '>=')],
+            ],
+            'target value: float, value: float with the same value as expression result, type: number, operator: <=' => [
+                1 - 0.83,
+                [new Compare(0.17, operator: '<=')],
+            ],
+            'target value: float as expression result, value: float with the same value, type: number, operator: <=' => [
+                0.17,
+                [new Compare(1 - 0.83, operator: '<=')],
+            ],
             'target value: float, value: float with the same value as expression result, type: string, operator: ==' => [
                 1 - 0.83,
                 [new Compare(0.17, type: CompareType::STRING)],
@@ -701,6 +713,11 @@ final class CompareTest extends RuleTestCase
                 1 - 0.83,
                 [new Compare(0.17, type: CompareType::ORIGINAL)],
                 ['' => ['Value must be equal to "0.17".']],
+            ],
+            'target value: float epsilon, value: doubled float epsilon, type: number, operator: ==' => [
+                PHP_FLOAT_EPSILON * 2,
+                [new Compare(PHP_FLOAT_EPSILON)],
+                ['' => ['Value must be equal to "2.2204460492503E-16".']],
             ],
 
             // Number / original specific, decimal places, directly provided values

--- a/tests/Rule/CompareTest.php
+++ b/tests/Rule/CompareTest.php
@@ -292,6 +292,10 @@ final class CompareTest extends RuleTestCase
                 $stringableUuid,
                 [new Compare($targetStringableUuid, type: CompareType::STRING, operator: '>')],
             ],
+            'target value: stringable uuidv4, value: greater stringable uuidv4, type: string, operator: >=' => [
+                $stringableUuid,
+                [new Compare($targetStringableUuid, type: CompareType::STRING, operator: '>=')],
+            ],
 
             // Original specific, datetime
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |