### PR TITLE
Skip empty iterable

### DIFF
--- a/docs/guide/en/built-in-rules-each.md
+++ b/docs/guide/en/built-in-rules-each.md
@@ -21,7 +21,7 @@ use Yiisoft\Validator\Rule\Integer;
 
 $rules = [
     // Applies to a whole set.
-    new Count(exactly: 3),
+    new Count(3),
     // Applies to individual set items.
     new Each(        
         // For single rules, wrapping with array / iterable is not necessary.
@@ -49,7 +49,7 @@ $rule = new Nested([
                         'y' => [new Number(min: -10, max: 10)],
                     ]),
                     'rgb' => new Each([
-                        new Count(exactly: 3),
+                        new Count(3),
                         new Number(min: 0, max: 255),
                     ]),
                 ]),

--- a/docs/guide/en/built-in-rules-nested.md
+++ b/docs/guide/en/built-in-rules-nested.md
@@ -191,7 +191,7 @@ $rule = new Nested([
                         'y' => [new Number(min: -10, max: 10)],
                     ]),
                     'rgb' => new Each([
-                        new Count(exactly: 3),
+                        new Count(3),
                         new Number(min: 0, max: 255),
                     ]),
                 ]),
@@ -227,7 +227,7 @@ $rule = new Nested([
     'charts.*.points.*.coordinates.x' => [new Number(min: -10, max: 10)],
     'charts.*.points.*.coordinates.y' => [new Number(min: -10, max: 10)],
     'charts.*.points.*.rgb' => [
-        new Count(exactly: 3),
+        new Count(3),
         new Number(min: 0, max: 255),
     ],
 ]);
@@ -246,7 +246,7 @@ $rule = new Nested([
         'y' => [new Number(min: -10, max: 10)],
     ]),
     'charts.*.points.*.rgb' => [
-        new Count(exactly: 3),
+        new Count(3),
         new Number(min: 0, max: 255),
     ],
 ]);

--- a/docs/guide/en/built-in-rules-required.md
+++ b/docs/guide/en/built-in-rules-required.md
@@ -7,7 +7,7 @@ By default, a value is considered empty only when it is either:
 - Not passed at all.
 - `null`.
 - An empty string (after trimming).
-- An empty array.
+- An empty iterable.
 
 ## Customizing empty condition
 

--- a/docs/guide/en/configuring-rules-via-php-attributes.md
+++ b/docs/guide/en/configuring-rules-via-php-attributes.md
@@ -267,7 +267,7 @@ final class RgbColorRuleSet extends Composite
     public function getRules(): array
     {
         return [
-            new Count(exactly: 3),
+            new Count(3),
             new Each([new Integer(min: 0, max: 255)])
         ];
     }
@@ -400,7 +400,7 @@ final class RgbColorRuleSet extends Composite
     public function getRules(): array
     {
         return [
-            new Count(exactly: 3),
+            new Count(3),
             new Each([new Integer(min: 0, max: 255)])
         ];
     }

--- a/docs/guide/en/creating-custom-rules.md
+++ b/docs/guide/en/creating-custom-rules.md
@@ -219,7 +219,7 @@ use Yiisoft\Validator\Rule\Each;
 use Yiisoft\Validator\Rule\Integer;
 
 $rules = [
-    new Count(exactly: 3),
+    new Count(3),
     new Each([new Integer(min: 0, max: 255)])
 ];
 ```
@@ -239,7 +239,7 @@ final class RgbColorRuleSet extends Composite
     public function getRules(): array
     {
         return [
-            new Count(exactly: 3),
+            new Count(3),
             new Each([new Integer(min: 0, max: 255)])
         ];
     }

--- a/src/EmptyCondition/WhenEmpty.php
+++ b/src/EmptyCondition/WhenEmpty.php
@@ -14,7 +14,7 @@ use function is_string;
  * - Not passed at all.
  * - `null`.
  * - An empty string (not trimmed by default).
- * - An empty array.
+ * - An empty iterable.
  *
  * With regard to validation process, a corresponding rule is skipped only if this condition is met and `WhenEmpty` is
  * set:
@@ -45,10 +45,27 @@ final class WhenEmpty
      */
     public function __invoke(mixed $value, bool $isAttributeMissing): bool
     {
-        if (is_string($value) && $this->trimString) {
-            $value = trim($value);
+        if ($isAttributeMissing || $value === null) {
+            return true;
         }
 
-        return $isAttributeMissing || $value === null || $value === [] || $value === '';
+        if (is_string($value)) {
+            if ($this->trimString) {
+                $value = trim($value);
+            }
+
+            return $value === '';
+        }
+
+        if (is_iterable($value)) {
+            /** @var mixed $item */
+            foreach ($value as $item) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Rule/Each.php
+++ b/src/Rule/Each.php
@@ -29,7 +29,7 @@ use Yiisoft\Validator\WhenInterface;
  *
  * ```php
  * $rules = [
- *     new Count(exactly: 3), // Not required for using with `Each`.
+ *     new Count(3), // Not required for using with `Each`.
  *     new Each([
  *         new Integer(min: 0, max: 255),
  *         // More rules can be added here.

--- a/src/Rule/Required.php
+++ b/src/Rule/Required.php
@@ -23,7 +23,7 @@ use Yiisoft\Validator\WhenInterface;
  * - Passed.
  * - Not `null`.
  * - Not an empty string (after trimming).
- * - Not an empty array.
+ * - Not an empty iterable.
  *
  * When using with other rules, it must come first.
  *

--- a/src/Rule/Trait/CountableLimitTrait.php
+++ b/src/Rule/Trait/CountableLimitTrait.php
@@ -123,11 +123,11 @@ trait CountableLimitTrait
         }
 
         if (
-            ($this->min !== null && $this->min <= 0) ||
-            ($this->max !== null && $this->max <= 0) ||
-            ($this->exactly !== null && $this->exactly <= 0)
+            ($this->min !== null && $this->min < 0) ||
+            ($this->max !== null && $this->max < 0) ||
+            ($this->exactly !== null && $this->exactly < 0)
         ) {
-            throw new InvalidArgumentException('Only positive values are allowed.');
+            throw new InvalidArgumentException('Only positive or zero values are allowed.');
         }
 
         if ($this->min !== null && $this->max !== null) {

--- a/src/SkipOnEmptyInterface.php
+++ b/src/SkipOnEmptyInterface.php
@@ -40,7 +40,7 @@ interface SkipOnEmptyInterface
      * `false` - never skip a rule (the validated value is always considered as not empty). Matching condition -
      * {@see NeverEmpty}.
      * - `true` - skip a rule when the validated value is empty: either not passed at all, `null`, an empty string (not
-     * trimmed by default) or an empty array. Matching condition - {@see WhenEmpty}.
+     * trimmed by default) or an empty iterable. Matching condition - {@see WhenEmpty}.
      * - `callable` - skip a rule when evaluated to `true`.
      *
      * Examples of custom callables with built-in condition:

--- a/tests/Rule/Base/LimitTestTrait.php
+++ b/tests/Rule/Base/LimitTestTrait.php
@@ -55,14 +55,11 @@ trait LimitTestTrait
     public function dataInitWithNonPositiveValues(): array
     {
         return [
-            [['min' => 0, 'max' => 2]],
             [['min' => -1, 'max' => 2]],
-            [['min' => 2, 'max' => 0]],
             [['min' => 2, 'max' => -1]],
             [['min' => -1, 'max' => 0]],
             [['min' => 0, 'max' => -1]],
             [['min' => -2, 'max' => -1]],
-            [['exactly' => 0]],
             [['exactly' => -1]],
         ];
     }
@@ -75,7 +72,7 @@ trait LimitTestTrait
         $ruleClass = $this->getRuleClass();
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Only positive values are allowed.');
+        $this->expectExceptionMessage('Only positive or zero values are allowed.');
         new $ruleClass(...$arguments);
     }
 

--- a/tests/Rule/CountTest.php
+++ b/tests/Rule/CountTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Validator\Tests\Rule;
 
+use ArrayIterator;
 use Countable;
 use stdClass;
 use Yiisoft\Validator\DataSet\SingleValueDataSet;
@@ -71,7 +72,7 @@ final class CountTest extends RuleTestCase
         return [
             [[0, 0, 0], [new Count(min: 3)]],
             [[0, 0, 0, 0], [new Count(min: 3)]],
-            [[0, 0, 0], [new Count(exactly: 3)]],
+            [[0, 0, 0], [new Count(3)]],
             [[], [new Count(max: 3)]],
             [[0, 0], [new Count(max: 3)]],
             [[0, 0, 0], [new Count(max: 3)]],
@@ -90,6 +91,10 @@ final class CountTest extends RuleTestCase
             ],
             'class attribute' => [
                 new CountDto(7),
+            ],
+            'value: iterator, exactly: 0, skipOnEmpty: true' => [
+                new ArrayIterator([]),
+                [new Count(1, skipOnEmpty: true)],
             ],
         ];
     }
@@ -190,7 +195,7 @@ final class CountTest extends RuleTestCase
 
             'custom not exactly message' => [
                 [0, 0, 0, 0],
-                [new Count(exactly: 3, notExactlyMessage: 'Custom not exactly message.')],
+                [new Count(3, notExactlyMessage: 'Custom not exactly message.')],
                 ['' => ['Custom not exactly message.']],
             ],
             'custom not exactly message with parameters' => [
@@ -217,6 +222,16 @@ final class CountTest extends RuleTestCase
                 new CountDto(),
                 null,
                 ['' => ['This value must contain at least 2 items.']],
+            ],
+            'value: array, exactly: 0' => [
+                [0],
+                [new Count(0)],
+                ['' => ['This value must contain exactly 0 items.']]
+            ],
+            'value: iterator, exactly: 0' => [
+                new ArrayIterator([]),
+                [new Count(1)],
+                ['' => ['This value must contain exactly 1 item.']]
             ],
         ];
     }

--- a/tests/Rule/CountTest.php
+++ b/tests/Rule/CountTest.php
@@ -226,12 +226,12 @@ final class CountTest extends RuleTestCase
             'value: array, exactly: 0' => [
                 [0],
                 [new Count(0)],
-                ['' => ['This value must contain exactly 0 items.']]
+                ['' => ['This value must contain exactly 0 items.']],
             ],
             'value: iterator, exactly: 0' => [
                 new ArrayIterator([]),
                 [new Count(1)],
-                ['' => ['This value must contain exactly 1 item.']]
+                ['' => ['This value must contain exactly 1 item.']],
             ],
         ];
     }

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -682,7 +682,7 @@ final class NestedTest extends RuleTestCase
         ];
         $yRules = [new Number(min: -10, max: 10)];
         $rgbRules = [
-            new Count(exactly: 3),
+            new Count(3),
             new Each([new Number(min: 0, max: 255)]),
         ];
 

--- a/tests/TestEnvironments/Php81/DataSet/ObjectDataSetTest.php
+++ b/tests/TestEnvironments/Php81/DataSet/ObjectDataSetTest.php
@@ -205,7 +205,7 @@ final class ObjectDataSetTest extends TestCase
                             ),
                         ]),
                         'rgb' => [
-                            new Count(exactly: 3),
+                            new Count(3),
                             new Each(
                                 [new Number(min: 0, max: 255)],
                                 incorrectInputMessage: 'Custom message 5.',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #431

Additional changes:

- Fix usages of `new Count(exactly: ...)` (an addition to #498).
- Allow `0` as a limit in `CountableLimitTrait`.