### PR TITLE
Add immutable setter for modifying `Validator::$defaultSkipOnEmptyCondition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Yii Validator Change Log
 
-## 1.0.1 under development
+## 1.1.0 under development
 
 - Enh #567: Add immutable setter for modifying `Validator::$defaultSkipOnEmptyCondition` (@arogachev)
 - Bug #586: Allow `0` as a limit in `CountableLimitTrait` (@arogachev)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1 under development
 
-- no changes in this release.
+- Enh #567: Add immutable setter for modifying `Validator::$defaultSkipOnEmptyCondition` (@arogachev)
 
 ## 1.0.0 February 22, 2023
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -81,7 +81,7 @@ final class Validator implements ValidatorInterface
     /**
      * An immutable setter to change default "skip on empty" condition.
      *
-     * @param callable $value A new raw non-normalized "skip on empty" value (see
+     * @param bool|callable|null $value A new raw non-normalized "skip on empty" value (see
      * {@see SkipOnEmptyInterface::getSkipOnEmpty()}).
      *
      * @return $this The new instance with a changed value.

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -78,6 +78,20 @@ final class Validator implements ValidatorInterface
             ?? new TranslatorAttributeTranslator($this->translator);
     }
 
+    /**
+     * An immutable setter to change default "skip on empty" condition.
+     * @param callable $value A new raw non-normalized "skip on empty" value (see
+     * {@see SkipOnEmptyInterface::getSkipOnEmpty()}).
+     * @return $this The new instance with a changed value.
+     * @see $defaultSkipOnEmptyCondition
+     */
+    public function withDefaultSkipOnEmptyCondition(mixed $value): static
+    {
+        $new = clone $this;
+        $new->defaultSkipOnEmptyCondition = SkipOnEmptyNormalizer::normalize($value);
+        return $new;
+    }
+
     public function validate(
         mixed $data,
         callable|iterable|object|string|null $rules = null,

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -80,9 +80,12 @@ final class Validator implements ValidatorInterface
 
     /**
      * An immutable setter to change default "skip on empty" condition.
+     *
      * @param callable $value A new raw non-normalized "skip on empty" value (see
      * {@see SkipOnEmptyInterface::getSkipOnEmpty()}).
+     *
      * @return $this The new instance with a changed value.
+     *
      * @see $defaultSkipOnEmptyCondition
      */
     public function withDefaultSkipOnEmptyCondition(mixed $value): static

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -88,7 +88,7 @@ final class Validator implements ValidatorInterface
      *
      * @see $defaultSkipOnEmptyCondition
      */
-    public function withDefaultSkipOnEmptyCondition(mixed $value): static
+    public function withDefaultSkipOnEmptyCondition(bool|callable|null $value): static
     {
         $new = clone $this;
         $new->defaultSkipOnEmptyCondition = SkipOnEmptyNormalizer::normalize($value);

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -62,6 +62,22 @@ class ValidatorTest extends TestCase
         );
     }
 
+    public function testWithDefaultSkipOnEmptyCondition(): void
+    {
+        $data = '';
+        $rule = new Length(1);
+        $validator = new Validator();
+
+        $result = $validator->validate($data, $rule);
+        $this->assertFalse($result->isValid());
+
+        $newValidator = $validator->withDefaultSkipOnEmptyCondition(true);
+        $this->assertNotSame($validator, $newValidator);
+
+        $result = $newValidator->validate($data, $rule);
+        $this->assertTrue($result->isValid());
+    }
+
     public function dataDataAndRulesCombinations(): array
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |
