### PR TITLE
Disable asterisk char escaping + Add `$escape` parameter to several methods of `Result`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New #597, #608: Add debug collector for `yiisoft/yii-debug` (@xepozz, @vjik)
 - New #610: Add `$escape` parameter to methods `Result::getAttributeErrorMessagesIndexedByPath()` and
   `Result::getErrorMessagesIndexedByPath()` that allow change or disable symbol which will be escaped in value path
-  elements. 
+  elements (@vjik)
 - Bug #612: Disable escaping of asterisk char in value path that returns by `Error::getValuePath(true)` (@vjik)
 
 ## 1.1.0 April 06, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.2.0 under development
 
 - New #597, #608: Add debug collector for `yiisoft/yii-debug` (@xepozz, @vjik)
+- New #610: Add `$escape` parameter to methods `Result::getAttributeErrorMessagesIndexedByPath()` and
+  `Result::getErrorMessagesIndexedByPath()` that allow change or disable symbol which will be escaped in value path
+  elements. 
 - Bug #612: Disable escaping of asterisk char in value path that returns by `Error::getValuePath(true)` (@vjik)
 
 ## 1.1.0 April 06, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0 under development
 
 - New #597, #608: Add debug collector for `yiisoft/yii-debug` (@xepozz, @vjik)
+- Bug #612: Disable escaping of asterisk char in value path that returns by `Error::getValuePath(true)` (@vjik)
 
 ## 1.1.0 April 06, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - New #610: Add `$escape` parameter to methods `Result::getAttributeErrorMessagesIndexedByPath()` and
   `Result::getErrorMessagesIndexedByPath()` that allow change or disable symbol which will be escaped in value path
   elements (@vjik)
-- Bug #612: Disable escaping of asterisk char in value path that returns by `Error::getValuePath(true)` (@vjik)
+- Bug #612: Disable escaping of asterisk char in value path returned by `Error::getValuePath(true)` (@vjik)
 
 ## 1.1.0 April 06, 2023
 

--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -178,8 +178,8 @@ A path can contain integer elements too (when using the `Each` rule for example)
 
 #### Resolving special characters collision in attribute names
 
-When the attribute name contains a path separator (dot `.` by default), they're automatically escaped using 
-a backslash (`\`) in the error messages list:
+When the attribute name in the error messages list contains a path separator (dot `.` by default),
+it is automatically escaped using a backslash (`\`):
 
 ```php
 [

--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -178,12 +178,12 @@ A path can contain integer elements too (when using the `Each` rule for example)
 
 #### Resolving special characters collision in attribute names
 
-When the attribute name contains a path separator (dot - `.` by default) or `Each` rule shortcut (asterisk -`*`), 
-they're automatically escaped using a backslash (`\`) in the error messages list:
+When the attribute name contains a path separator (dot `.` by default), they're automatically escaped using 
+a backslash (`\`) in the error messages list:
 
 ```php
 [
-    '\*country\.code' => ['Value cannot be blank.'],
+    'country\.code' => ['Value cannot be blank.'],
 ],
 ```
 
@@ -195,7 +195,7 @@ use Yiisoft\Validator\Rule\In;
 use Yiisoft\Validator\Rule\Required;
 
 $rules = [
-    '*country.code' => [
+    'country.code' => [
         new Required();
         new In(['ru', 'en'], skipOnError: true),
     ],

--- a/src/AfterInitAttributeEventInterface.php
+++ b/src/AfterInitAttributeEventInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Validator;
 
-use Attribute;
 use Yiisoft\Validator\RulesProvider\AttributesRulesProvider;
 
 /**

--- a/src/Error.php
+++ b/src/Error.php
@@ -95,9 +95,9 @@ final class Error
      * A getter for {@see $valuePath} property. Returns a sequence of keys determining where a value caused the
      * validation error is located within a nested structure.
      *
-     * @param bool|string|null $escape Symbol that will be escaped with a backslash char (`\`) into path elements.
-     * When is null value path returns without escaping.
-     * Boolean value is deprecated and will be removed in the next major release. Boolean value processing so:
+     * @param bool|string|null $escape Symbol that will be escaped with a backslash char (`\`) in path elements.
+     * When it's null path is returned without escaping.
+     * Boolean value is deprecated and will be removed in the next major release. Boolean value processed in the following way:
      *  - `false` as null,
      *  - `true` as dot (`.`).
      *
@@ -116,7 +116,7 @@ final class Error
         }
 
         if (mb_strlen($escape) !== 1) {
-            throw new InvalidArgumentException('Escape symbol must contain exactly one character.');
+            throw new InvalidArgumentException('Escape symbol must be exactly one character.');
         }
 
         return array_map(

--- a/src/Result.php
+++ b/src/Result.php
@@ -171,8 +171,7 @@ final class Result
         string $attribute,
         string $separator = '.',
         ?string $escape = '.',
-    ): array
-    {
+    ): array {
         $errors = [];
         foreach ($this->errors as $error) {
             $firstItem = $error->getValuePath()[0] ?? '';

--- a/src/Result.php
+++ b/src/Result.php
@@ -82,7 +82,7 @@ final class Result
     {
         $errors = [];
         foreach ($this->errors as $error) {
-            $stringValuePath = implode($separator, $error->getValuePath(true));
+            $stringValuePath = implode($separator, $error->getValuePath($separator));
             $errors[$stringValuePath][] = $error->getMessage();
         }
 
@@ -172,7 +172,7 @@ final class Result
                 continue;
             }
 
-            $valuePath = implode($separator, array_slice($error->getValuePath(true), 1));
+            $valuePath = implode($separator, array_slice($error->getValuePath($separator), 1));
             $errors[$valuePath][] = $error->getMessage();
         }
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -73,16 +73,18 @@ final class Result
      * Each value is an array of error message strings.
      *
      * @param string $separator Attribute path separator. Dot is used by default.
+     * @param string|null $escape Symbol that will be escaped with a backslash char (`\`) into path elements.
+     * When is null value path returns without escaping.
      *
      * @return array Arrays of error messages indexed by attribute path.
      *
      * @psalm-return array<string, non-empty-list<string>>
      */
-    public function getErrorMessagesIndexedByPath(string $separator = '.'): array
+    public function getErrorMessagesIndexedByPath(string $separator = '.', ?string $escape = '.'): array
     {
         $errors = [];
         foreach ($this->errors as $error) {
-            $stringValuePath = implode($separator, $error->getValuePath($separator));
+            $stringValuePath = implode($separator, $error->getValuePath($escape));
             $errors[$stringValuePath][] = $error->getMessage();
         }
 
@@ -158,12 +160,18 @@ final class Result
      *
      * @param string $attribute Attribute name.
      * @param string $separator Attribute path separator. Dot is used by default.
+     * @param string|null $escape Symbol that will be escaped with a backslash char (`\`) into path elements.
+     * When is null value path returns without escaping.
      *
      * @return array Arrays of error messages for the attribute specified indexed by attribute path.
      *
      * @psalm-return array<string, non-empty-list<string>>
      */
-    public function getAttributeErrorMessagesIndexedByPath(string $attribute, string $separator = '.'): array
+    public function getAttributeErrorMessagesIndexedByPath(
+        string $attribute,
+        string $separator = '.',
+        ?string $escape = '.',
+    ): array
     {
         $errors = [];
         foreach ($this->errors as $error) {
@@ -172,7 +180,7 @@ final class Result
                 continue;
             }
 
-            $valuePath = implode($separator, array_slice($error->getValuePath($separator), 1));
+            $valuePath = implode($separator, array_slice($error->getValuePath($escape), 1));
             $errors[$valuePath][] = $error->getMessage();
         }
 

--- a/src/Result.php
+++ b/src/Result.php
@@ -73,8 +73,8 @@ final class Result
      * Each value is an array of error message strings.
      *
      * @param string $separator Attribute path separator. Dot is used by default.
-     * @param string|null $escape Symbol that will be escaped with a backslash char (`\`) into path elements.
-     * When is null value path returns without escaping.
+     * @param string|null $escape Symbol that will be escaped with a backslash char (`\`) in path elements.
+     * When it's null path is returned without escaping.
      *
      * @return array Arrays of error messages indexed by attribute path.
      *
@@ -160,8 +160,8 @@ final class Result
      *
      * @param string $attribute Attribute name.
      * @param string $separator Attribute path separator. Dot is used by default.
-     * @param string|null $escape Symbol that will be escaped with a backslash char (`\`) into path elements.
-     * When is null value path returns without escaping.
+     * @param string|null $escape Symbol that will be escaped with a backslash char (`\`) in path elements.
+     * When it's null path is returned without escaping.
      *
      * @return array Arrays of error messages for the attribute specified indexed by attribute path.
      *

--- a/src/Rule/Nested.php
+++ b/src/Rule/Nested.php
@@ -499,7 +499,7 @@ final class Nested implements
                 $breakWhile = false;
 
                 $lastValuePath = array_pop($parts);
-                $lastValuePath = ltrim($lastValuePath, '.');
+                $lastValuePath = ltrim($lastValuePath, self::SEPARATOR);
                 $lastValuePath = str_replace('\\' . self::EACH_SHORTCUT, self::EACH_SHORTCUT, $lastValuePath);
 
                 $remainingValuePath = implode(self::EACH_SHORTCUT, $parts);

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Validator\Error;
+
+final class ErrorTest extends TestCase
+{
+    public function dataGetValuePath(): array
+    {
+        return [
+            'null' => [
+                ['user', 'data.age'],
+                ['user', 'data.age'],
+                null,
+            ],
+            'symbol' => [
+                ['user', 'the.data\-age'],
+                ['user', 'the.data-age'],
+                '-',
+            ],
+
+            // deprecated
+            'true' => [
+                ['user', 'data\.age'],
+                ['user', 'data.age'],
+                true,
+            ],
+
+            // deprecated
+            'false' => [
+                ['user', 'data.age'],
+                ['user', 'data.age'],
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataGetValuePath
+     */
+    public function testGetValuePath(array $expectedValuePath, array $valuePath, bool|string|null $escape): void
+    {
+        $error = new Error('', valuePath: $valuePath);
+
+        $this->assertSame($expectedValuePath, $error->getValuePath($escape));
+    }
+
+    public function testTooLongEscapeSymbol(): void
+    {
+        $error = new Error('');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Escape symbol must contain exactly one character.');
+        $error->getValuePath('..');
+    }
+}

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -60,7 +60,7 @@ final class ErrorTest extends TestCase
         $error = new Error('');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Escape symbol must contain exactly one character.');
+        $this->expectExceptionMessage('Escape symbol must be exactly one character.');
         $error->getValuePath('..');
     }
 }

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -23,6 +23,11 @@ final class ErrorTest extends TestCase
                 ['user', 'the.data-age'],
                 '-',
             ],
+            'emoji' => [
+                ['user', 'the.data\😎age'],
+                ['user', 'the.data😎age'],
+                '😎',
+            ],
 
             // deprecated
             'true' => [

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -206,6 +206,30 @@ class ResultTest extends TestCase
         );
     }
 
+    public function testEscapeInGetErrorMessagesIndexedByPath(): void
+    {
+        $result = (new Result)->addError('e1', valuePath: ['user', 'meta.the-age']);
+
+        $this->assertSame(
+            [
+                'user.meta.the\-age' => ['e1'],
+            ],
+            $result->getErrorMessagesIndexedByPath(escape: '-'),
+        );
+    }
+
+    public function testEscapeInGetAttributeErrorMessagesIndexedByPath(): void
+    {
+        $result = (new Result)->addError('e1', valuePath: ['user', 'data', 'meta.the-age']);
+
+        $this->assertSame(
+            [
+                'data.meta.the\-age' => ['e1'],
+            ],
+            $result->getAttributeErrorMessagesIndexedByPath('user', escape: '-'),
+        );
+    }
+
     private function createAttributeErrorResult(): Result
     {
         $result = new Result();

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -208,7 +208,7 @@ class ResultTest extends TestCase
 
     public function testEscapeInGetErrorMessagesIndexedByPath(): void
     {
-        $result = (new Result)->addError('e1', valuePath: ['user', 'meta.the-age']);
+        $result = (new Result())->addError('e1', valuePath: ['user', 'meta.the-age']);
 
         $this->assertSame(
             [
@@ -220,7 +220,7 @@ class ResultTest extends TestCase
 
     public function testEscapeInGetAttributeErrorMessagesIndexedByPath(): void
     {
-        $result = (new Result)->addError('e1', valuePath: ['user', 'data', 'meta.the-age']);
+        $result = (new Result())->addError('e1', valuePath: ['user', 'data', 'meta.the-age']);
 
         $this->assertSame(
             [

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -875,10 +875,10 @@ final class NestedTest extends RuleTestCase
                 ],
                 array_slice($errorMessages, 0, 5),
                 [
-                    'charts\.list.0.points\*list.0.coordinates\.data.x' => [$errorMessages[0], $errorMessages[1]],
-                    'charts\.list.0.points\*list.0.coordinates\.data.y' => [$errorMessages[2]],
-                    'charts\.list.0.points\*list.0.rgb.0' => [$errorMessages[3]],
-                    'charts\.list.0.points\*list.0.rgb.1' => [$errorMessages[4]],
+                    'charts\.list.0.points*list.0.coordinates\.data.x' => [$errorMessages[0], $errorMessages[1]],
+                    'charts\.list.0.points*list.0.coordinates\.data.y' => [$errorMessages[2]],
+                    'charts\.list.0.points*list.0.rgb.0' => [$errorMessages[3]],
+                    'charts\.list.0.points*list.0.rgb.1' => [$errorMessages[4]],
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |  #610 
