### PR TITLE
Fix docs for getErrorMessagesIndexedByAttribute - array keys must be strings

### DIFF
--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -128,7 +128,7 @@ Returning to the previous example, when `name` and `email` belong to a `user` at
 ];
 ```
 
-Also keep in mind that attribute names are always must be strings, even when used with `Each`:
+Also keep in mind that attribute names must be strings, even when used with `Each`:
 
 ```php
 $rule = new Each([new Number(min: 21)]),

--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -128,19 +128,26 @@ Returning to the previous example, when `name` and `email` belong to a `user` at
 ];
 ```
 
-Also keep in mind that attribute names are always strings, even when used with `Each`:
+Also keep in mind that attribute names are always must be strings, even when used with `Each`:
 
 ```php
 $rule = new Each([new Number(min: 21)]),
 ```
 
-Given `[21, 22, 23, 20]` input, the output will be: 
+Given `[21, 22, 23, 20]` input throw exception, because array keys is numbers: 
+
+```php
+InvalidArgumentException
+Top level attributes can only have string type.
+```
+But if given array with string keys `['1' => 21, '2' => 22, '3' => 23, '4' => 20]`, the output will be:
 
 ```php
 [
-    '1' => ['Value must be no less than 21.'],
-    '2' => ['Value must be no less than 21.'],
-],
+    '4' => [
+        0 => 'Value must be no less than 21.'
+    ]
+]
 ```
 
 ### Error messages indexed by path

--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -134,17 +134,20 @@ Also keep in mind that attribute names must be strings, even when used with `Eac
 $rule = new Each([new Number(min: 21)]),
 ```
 
-Given `[21, 22, 23, 20]` input throw exception, because default array keys is numbers: 
+Given `[21, 22, 23, 20]` input throw exception, because default array keys is int:
 
 ```php
 InvalidArgumentException
 Top level attributes can only have string type.
 ```
-But if given array with string keys `['1' => 21, '2' => 22, '3' => 23, '4' => 20]`, the output will be:
+
+Even  array `['1' => 21, '2' => 22, '3' => 23, '4' => 20]` will cause an error, because PHP [will cast keys to the int type].
+
+But if given array with string keys `['1a' => 21, '2b' => 22, '3c' => 23, '4d' => 20]`, the output will be:
 
 ```php
 [
-    '4' => [
+    '4d' => [
         0 => 'Value must be no less than 21.'
     ]
 ]
@@ -288,3 +291,4 @@ $result->getAttributeErrors('email');
 ```
 
 [Using keys containing separator / shortcut]: built-in-rules-nested.md#using-keys-containing-separator--shortcut
+[will cast keys to the int type]: https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.readonly-properties

--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -134,7 +134,7 @@ Also keep in mind that attribute names are always must be strings, even when use
 $rule = new Each([new Number(min: 21)]),
 ```
 
-Given `[21, 22, 23, 20]` input throw exception, because array keys is numbers: 
+Given `[21, 22, 23, 20]` input throw exception, because default array keys is numbers: 
 
 ```php
 InvalidArgumentException

--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -141,7 +141,7 @@ InvalidArgumentException
 Top level attributes can only have string type.
 ```
 
-Even  array `['1' => 21, '2' => 22, '3' => 23, '4' => 20]` will cause an error, because PHP [will cast keys to the int type].
+Even array `['1' => 21, '2' => 22, '3' => 23, '4' => 20]` will cause an error, because PHP [will cast keys to the int type].
 
 But if given array with string keys `['1a' => 21, '2b' => 22, '3c' => 23, '4d' => 20]`, the output will be:
 

--- a/docs/guide/en/result.md
+++ b/docs/guide/en/result.md
@@ -134,12 +134,7 @@ Also keep in mind that attribute names must be strings, even when used with `Eac
 $rule = new Each([new Number(min: 21)]),
 ```
 
-Given `[21, 22, 23, 20]` input throw exception, because default array keys is int:
-
-```php
-InvalidArgumentException
-Top level attributes can only have string type.
-```
+With input containing non-string keys for top level attributes, for example, `[21, 22, 23, 20]`, InvalidArgumentException` will be thrown.
 
 Even array `['1' => 21, '2' => 22, '3' => 23, '4' => 20]` will cause an error, because PHP [will cast keys to the int type].
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | ❌
