### PR TITLE
Change type of `$escape` argument in `Error::getValuePath()` from `bool|string|null` to `string|null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   (@arogachev)
 - Chg #679: Change type of `$rule` argument in `RuleHandlerInterface::validate()` from `object` to `RuleInterface`
   (@arogachev)
+- Chg #613: Change type of `$escape` argument in `Error::getValuePath()` from `bool|string|null` to `string|null` 
+  (@arogachev)
 
 ## 1.3.0 April 04, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,3 +27,6 @@ for both A and B.
 
   public function validate(mixed $value, RuleInterface $rule, ValidationContext $context): Result;
   ```
+  
+* The type of `$escape` argument in `Yiisoft\Validator\Error::getValuePath()` changed from `bool|string|null` to 
+  `string|null`. If you used `bool`, replace `false` with `null` and `true` with dot (`.`).

--- a/src/Error.php
+++ b/src/Error.php
@@ -20,8 +20,8 @@ final class Error
     public const MESSAGE_TRANSLATE = 2;
 
     /**
-     * @param string $message The raw validation error message. Can be a simple text or a template with placeholders enclosed
-     * in curly braces (`{}`). In the end of the validation it will be translated using configured translator.
+     * @param string $message The raw validation error message. Can be a simple text or a template with placeholders
+     * enclosed in curly braces (`{}`). In the end of the validation it will be translated using configured translator.
      * {@see SimpleMessageFormatter} is usually enough, but for more complex translations
      * {@see IntlMessageFormatter} can be used (requires "intl" PHP extension). Examples:
      *

--- a/src/Error.php
+++ b/src/Error.php
@@ -106,24 +106,16 @@ final class Error
      * A getter for {@see $valuePath} property. Returns a sequence of keys determining where a value caused the
      * validation error is located within a nested structure.
      *
-     * @param bool|string|null $escape Symbol that will be escaped with a backslash char (`\`) in path elements.
+     * @param string|null $escape Symbol that will be escaped with a backslash char (`\`) in path elements.
      * When it's null path is returned without escaping.
-     * Boolean value is deprecated and will be removed in the next major release. Boolean value processed in the following way:
-     *  - `false` as null,
-     *  - `true` as dot (`.`).
      *
      * @return array A list of keys for nested structures or an empty array otherwise.
-     *
      * @psalm-return list<int|string>
      */
-    public function getValuePath(bool|string|null $escape = false): array
+    public function getValuePath(string|null $escape = null): array
     {
-        if ($escape === false || $escape === null) {
+        if ($escape === null) {
             return $this->valuePath;
-        }
-
-        if ($escape === true) {
-            $escape = '.';
         }
 
         if (mb_strlen($escape) !== 1) {

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -28,19 +28,10 @@ final class ErrorTest extends TestCase
                 ['user', 'the.data😎age'],
                 '😎',
             ],
-
-            // deprecated
-            'true' => [
+            'dot' => [
                 ['user', 'data\.age'],
                 ['user', 'data.age'],
-                true,
-            ],
-
-            // deprecated
-            'false' => [
-                ['user', 'data.age'],
-                ['user', 'data.age'],
-                false,
+                '.',
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
