### PR TITLE
Fix don't usage PHP attributes in `RulesNormalizer::normalize()` + make `$rules` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Enh #726: Refactor `Result::add()`: took `array_merge()` out of the `foreach` (@lav45)
 - Chg #583: Change "attribute" to "property" in class/trait/method/variable/placeholder names (@vjik)
 - Enh #733: Make parameter `$rules` in `RulesNormalizer::normalize()` optional (@vjik)
-- Bug #733: Fix don't usage rules provided by data object PHP attributes in `RulesNormalizer::normalize()` (@vjik)
+- Bug #733: Rules provided by data object PHP attributes were not used in  `RulesNormalizer::normalize()` (@vjik)
 
 ## 1.4.1 June 11, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   (@arogachev)
 - Enh #726: Refactor `Result::add()`: took `array_merge()` out of the `foreach` (@lav45)
 - Chg #583: Change "attribute" to "property" in class/trait/method/variable/placeholder names (@vjik)
+- Enh #733: Make parameter `$rules` in `RulesNormalizer::normalize()` optional (@vjik)
+- Bug #733: Fix don't usage rules provided by data object PHP attributes in `RulesNormalizer::normalize()` (@vjik)
 
 ## 1.4.1 June 11, 2024
 

--- a/src/Helper/RulesNormalizer.php
+++ b/src/Helper/RulesNormalizer.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Validator\Helper;
 
 use InvalidArgumentException;
 use ReflectionException;
+use Yiisoft\Validator\DataSetInterface;
 use Yiisoft\Validator\RuleInterface;
 use Yiisoft\Validator\RulesProvider\AttributesRulesProvider;
 use Yiisoft\Validator\RulesProviderInterface;
@@ -76,7 +77,7 @@ final class RulesNormalizer
      * @psalm-return NormalizedRulesMap
      */
     public static function normalize(
-        callable|iterable|object|string|null $rules,
+        callable|iterable|object|string|null $rules = null,
         mixed $data = null,
         ?callable $defaultSkipOnEmptyCondition = null,
     ): array {
@@ -162,8 +163,14 @@ final class RulesNormalizer
         }
 
         if ($rules === null) {
-            return $data instanceof RulesProviderInterface
-                ? $data->getRules()
+            if ($data instanceof RulesProviderInterface) {
+                return $data->getRules();
+            }
+            if ($data instanceof DataSetInterface) {
+                return [];
+            }
+            return is_object($data)
+                ? (new AttributesRulesProvider($data))->getRules()
                 : [];
         }
 

--- a/tests/Helper/RulesNormalizerTest.php
+++ b/tests/Helper/RulesNormalizerTest.php
@@ -8,9 +8,11 @@ use PHPUnit\Framework\TestCase;
 use Yiisoft\Validator\Helper\RulesNormalizer;
 use Yiisoft\Validator\Result;
 use Yiisoft\Validator\Rule\Callback;
+use Yiisoft\Validator\Rule\Length;
 use Yiisoft\Validator\Rule\Number;
 use Yiisoft\Validator\Rule\Required;
 use Yiisoft\Validator\RuleInterface;
+use Yiisoft\Validator\Tests\Support\Data\ObjectWithAttributesOnly;
 use Yiisoft\Validator\Tests\Support\Data\ObjectWithDifferentPropertyVisibility;
 
 final class RulesNormalizerTest extends TestCase
@@ -35,6 +37,12 @@ final class RulesNormalizerTest extends TestCase
                 ],
                 ObjectWithDifferentPropertyVisibility::class,
             ],
+            'data-object-with-attributes' => [
+                'expected' => [
+                    'name' => [Length::class],
+                ],
+                'data' => new ObjectWithAttributesOnly(),
+            ],
         ];
     }
 
@@ -52,7 +60,7 @@ final class RulesNormalizerTest extends TestCase
      */
     public function testNormalizeWithArrayResult(
         array $expected,
-        callable|iterable|object|string|null $rules,
+        callable|iterable|object|string|null $rules = null,
         mixed $data = null
     ): void {
         $rules = RulesNormalizer::normalize($rules, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
