### PR TITLE
Fix incorrect operation `Each (new Nested)` rule for iterable of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.1 under development
 
-- Bug #768: Fix incorrect operation `Each (new Nested)` rule for iterable of objects (@Enjoyzz)
+- Bug #751: Fix incorrect `Nested` rule processing within `Each` (@Enjoyzz)
 
 ## 2.3.0 May 07, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.1 under development
 
-- no changes in this release.
+- Bug #768: Fix incorrect operation `Each (new Nested)` rule for iterable of objects (@Enjoyzz)
 
 ## 2.3.0 May 07, 2025
 

--- a/src/Rule/NestedHandler.php
+++ b/src/Rule/NestedHandler.php
@@ -34,6 +34,12 @@ final class NestedHandler implements RuleHandlerInterface
         $value = $context->getParameter(ValidationContext::PARAMETER_VALUE_AS_ARRAY) ?? $value;
 
         if ($rule->getRules() === null) {
+            if (is_array($value)) {
+                foreach ($value as $item) {
+                    return $this->validate($item, $rule, $context);
+                }
+            }
+
             if (!is_object($value)) {
                 return (new Result())->addError($rule->getNoRulesWithNoObjectMessage(), [
                     'property' => $context->getTranslatedProperty(),
@@ -79,7 +85,8 @@ final class NestedHandler implements RuleHandlerInterface
                     [
                         'path' => $valuePath,
                         'property' => $context->getTranslatedProperty(),
-                        'Property' => $context->getCapitalizedTranslatedProperty(),                    ],
+                        'Property' => $context->getCapitalizedTranslatedProperty(),
+                    ],
                     $valuePathList,
                 );
 

--- a/src/Rule/NestedHandler.php
+++ b/src/Rule/NestedHandler.php
@@ -44,7 +44,6 @@ final class NestedHandler implements RuleHandlerInterface
             return $context->validate($dataSet);
         }
 
-        /** @var mixed $value */
         $value = $context->getParameter(ValidationContext::PARAMETER_VALUE_AS_ARRAY) ?? $value;
 
         if (is_array($value)) {

--- a/src/Rule/NestedHandler.php
+++ b/src/Rule/NestedHandler.php
@@ -30,16 +30,7 @@ final class NestedHandler implements RuleHandlerInterface
             throw new UnexpectedRuleException(Nested::class, $rule);
         }
 
-        /** @var mixed $value */
-        $value = $context->getParameter(ValidationContext::PARAMETER_VALUE_AS_ARRAY) ?? $value;
-
         if ($rule->getRules() === null) {
-            if (is_array($value)) {
-                foreach ($value as $item) {
-                    return $this->validate($item, $rule, $context);
-                }
-            }
-
             if (!is_object($value)) {
                 return (new Result())->addError($rule->getNoRulesWithNoObjectMessage(), [
                     'property' => $context->getTranslatedProperty(),
@@ -52,6 +43,9 @@ final class NestedHandler implements RuleHandlerInterface
 
             return $context->validate($dataSet);
         }
+
+        /** @var mixed $value */
+        $value = $context->getParameter(ValidationContext::PARAMETER_VALUE_AS_ARRAY) ?? $value;
 
         if (is_array($value)) {
             $data = $value;

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -1505,20 +1505,19 @@ final class NestedTest extends RuleTestCase
     public function testWithIterableOfObjects(): void
     {
         $obj = (new NestedIterableOfObjects())->setCollection([
-            new ObjectForIterableCollection('', '')
+            new ObjectForIterableCollection('', ''),
         ]);
         $result = (new Validator())->validate($obj);
         $this->assertFalse($result->isValid());
         $this->assertCount(4, $result->getErrorMessages());
 
         $obj = (new NestedIterableOfObjects())->setCollection([
-            new ObjectForIterableCollection('12345', 'myName')
+            new ObjectForIterableCollection('12345', 'myName'),
         ]);
         $result = (new Validator())->validate($obj);
         $this->assertTrue($result->isValid());
         $this->assertCount(0, $result->getErrorMessages());
     }
-
 
     /**
      * @see https://github.com/yiisoft/validator/issues/751

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -1539,7 +1539,7 @@ final class NestedTest extends RuleTestCase
         $this->assertSame([
             'collection.0.id' => [
                 'Id cannot be blank.',
-                'Id must be a string. null given.'
+                'Id must be a string. null given.',
             ]
         ], $result->getErrorMessagesIndexedByPath());
     }

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -1536,8 +1536,12 @@ final class NestedTest extends RuleTestCase
         $result = (new Validator())->validate($classB);
 
         $this->assertFalse($result->isValid());
-        $this->assertCount(2, $result->getErrorMessages());
-        $this->assertSame('Id cannot be blank.', $result->getErrorMessages()[0]);
+        $this->assertSame([
+            'collection.0.id' => [
+                'Id cannot be blank.',
+                'Id must be a string. null given.'
+            ]
+        ], $result->getErrorMessagesIndexedByPath());
     }
 
     /**
@@ -1551,9 +1555,7 @@ final class NestedTest extends RuleTestCase
         };
 
         $classB = new class () {
-            #[Each([
-                new Nested()
-            ])]
+            #[Each([new Nested()])]
             public $array_of_a;
         };
 
@@ -1561,7 +1563,6 @@ final class NestedTest extends RuleTestCase
         $result = (new Validator())->validate($classB);
 
         $this->assertFalse($result->isValid());
-        $this->assertCount(1, $result->getErrorMessages());
-        $this->assertSame('Id cannot be blank.', $result->getErrorMessages()[0]);
+        $this->assertSame(['array_of_a.0.id' => ['Id cannot be blank.']], $result->getErrorMessagesIndexedByPath());
     }
 }

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -40,6 +40,8 @@ use Yiisoft\Validator\Tests\Support\Data\EachNestedObjects\Foo;
 use Yiisoft\Validator\Tests\Support\Data\InheritAttributesObject\InheritAttributesObject;
 use Yiisoft\Validator\Tests\Support\Data\IteratorWithBooleanKey;
 use Yiisoft\Validator\Tests\Support\Data\NestedHookProvider\NestedObjectWithPostValidationHook;
+use Yiisoft\Validator\Tests\Support\Data\NestedIterableOfObjects;
+use Yiisoft\Validator\Tests\Support\Data\ObjectForIterableCollection;
 use Yiisoft\Validator\Tests\Support\Data\ObjectWithDifferentPropertyVisibility;
 use Yiisoft\Validator\Tests\Support\Data\ObjectWithNestedObject;
 use Yiisoft\Validator\Tests\Support\Helper\OptionsHelper;
@@ -51,6 +53,7 @@ use Yiisoft\Validator\ValidationContext;
 use Yiisoft\Validator\Validator;
 
 use function array_slice;
+use function PHPUnit\Framework\assertSame;
 
 final class NestedTest extends RuleTestCase
 {
@@ -1499,4 +1502,22 @@ final class NestedTest extends RuleTestCase
     {
         return [Nested::class, NestedHandler::class];
     }
+
+    public function testWithIterableOfObjects(): void
+    {
+        $obj = (new NestedIterableOfObjects())->setCollection([
+            new ObjectForIterableCollection('', '')
+        ]);
+        $result = (new Validator())->validate($obj);
+        $this->assertFalse($result->isValid());
+        $this->assertCount(4, $result->getErrorMessages());
+
+        $obj = (new NestedIterableOfObjects())->setCollection([
+            new ObjectForIterableCollection('12345', 'myName')
+        ]);
+        $result = (new Validator())->validate($obj);
+        $this->assertTrue($result->isValid());
+        $this->assertCount(0, $result->getErrorMessages());
+    }
+
 }

--- a/tests/Rule/NestedTest.php
+++ b/tests/Rule/NestedTest.php
@@ -1540,7 +1540,7 @@ final class NestedTest extends RuleTestCase
             'collection.0.id' => [
                 'Id cannot be blank.',
                 'Id must be a string. null given.',
-            ]
+            ],
         ], $result->getErrorMessagesIndexedByPath());
     }
 

--- a/tests/Support/Data/NestedIterableOfObjects.php
+++ b/tests/Support/Data/NestedIterableOfObjects.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests\Support\Data;
+
+use Yiisoft\Validator\Rule\Nested;
+
+
+final class NestedIterableOfObjects
+{
+    /**
+     * @var iterable<ObjectForIterableCollection>
+     */
+    #[Nested]
+    private iterable $collection = [];
+
+    public function setCollection(iterable $collection): NestedIterableOfObjects
+    {
+        $this->collection = $collection;
+        return $this;
+    }
+
+    public function getCollection(): iterable
+    {
+        return $this->collection;
+    }
+
+
+}

--- a/tests/Support/Data/NestedIterableOfObjects.php
+++ b/tests/Support/Data/NestedIterableOfObjects.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Validator\Tests\Support\Data;
 
 use Yiisoft\Validator\Rule\Nested;
 
-
 final class NestedIterableOfObjects
 {
     /**
@@ -15,7 +14,7 @@ final class NestedIterableOfObjects
     #[Nested]
     private iterable $collection = [];
 
-    public function setCollection(iterable $collection): NestedIterableOfObjects
+    public function setCollection(iterable $collection): self
     {
         $this->collection = $collection;
         return $this;
@@ -25,6 +24,4 @@ final class NestedIterableOfObjects
     {
         return $this->collection;
     }
-
-
 }

--- a/tests/Support/Data/NestedIterableOfObjects.php
+++ b/tests/Support/Data/NestedIterableOfObjects.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Validator\Tests\Support\Data;
 
+use Yiisoft\Validator\Rule\Each;
 use Yiisoft\Validator\Rule\Nested;
 
 final class NestedIterableOfObjects
@@ -11,7 +12,7 @@ final class NestedIterableOfObjects
     /**
      * @var iterable<ObjectForIterableCollection>
      */
-    #[Nested]
+    #[Each(new Nested())]
     private iterable $collection = [];
 
     public function setCollection(iterable $collection): self

--- a/tests/Support/Data/ObjectForIterableCollection.php
+++ b/tests/Support/Data/ObjectForIterableCollection.php
@@ -7,18 +7,15 @@ namespace Yiisoft\Validator\Tests\Support\Data;
 use Yiisoft\Validator\Rule\Length;
 use Yiisoft\Validator\Rule\Required;
 
-
 final class ObjectForIterableCollection
 {
     public function __construct(
         #[Required]
         #[Length(min: 5)]
         public string $id,
-
         #[Required]
         #[Length(min: 5)]
         public ?string $name = null,
     ) {
     }
-
 }

--- a/tests/Support/Data/ObjectForIterableCollection.php
+++ b/tests/Support/Data/ObjectForIterableCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Validator\Tests\Support\Data;
+
+use Yiisoft\Validator\Rule\Length;
+use Yiisoft\Validator\Rule\Required;
+
+
+final class ObjectForIterableCollection
+{
+    public function __construct(
+        #[Required]
+        #[Length(min: 5)]
+        public string $id,
+
+        #[Required]
+        #[Length(min: 5)]
+        public ?string $name = null,
+    ) {
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
