### PR TITLE
Fix date and time comparison message grammar

### DIFF
--- a/messages/de/yii-validator.php
+++ b/messages/de/yii-validator.php
@@ -182,8 +182,6 @@ return [
      * @see \Yiisoft\Validator\Rule\Date\DateTime
      * @see \Yiisoft\Validator\Rule\Date\Time
      */
-    '{Property} must be no early than {limit}.' => '{Property} darf nicht früher als {limit} sein.',
-    '{Property} must be no late than {limit}.' => '{Property} darf nicht später als {limit} sein.',
     '{Property} must be no earlier than {limit}.' => '{Property} darf nicht früher als {limit} sein.',
     '{Property} must be no later than {limit}.' => '{Property} darf nicht später als {limit} sein.',
 

--- a/messages/pl/yii-validator.php
+++ b/messages/pl/yii-validator.php
@@ -179,8 +179,8 @@ return [
      * @see DateTime
      * @see Time
      */
-    '{Property} must be no early than {limit}.' => '{Property} nie może być wcześniej niż {limit}.',
-    '{Property} must be no late than {limit}.' => '{Property} nie może być później niż {limit}.',
+    '{Property} must be no earlier than {limit}.' => '{Property} nie może być wcześniej niż {limit}.',
+    '{Property} must be no later than {limit}.' => '{Property} nie może być później niż {limit}.',
 
     /**
      * @see Date

--- a/messages/pt-BR/yii-validator.php
+++ b/messages/pt-BR/yii-validator.php
@@ -159,8 +159,6 @@ return [
      * @see \Yiisoft\Validator\Rule\Date\DateTime
      * @see \Yiisoft\Validator\Rule\Date\Time
      */
-    '{Property} must be no early than {limit}.' => '{Property} não deve ser anterior a {limit}.',
-    '{Property} must be no late than {limit}.' => '{Property} não deve ser posterior a {limit}.',
     '{Property} must be no earlier than {limit}.' => '{Property} não deve ser anterior a {limit}.',
     '{Property} must be no later than {limit}.' => '{Property} não deve ser posterior a {limit}.',
 

--- a/messages/ru/yii-validator.php
+++ b/messages/ru/yii-validator.php
@@ -167,8 +167,6 @@ return [
      * @see \Yiisoft\Validator\Rule\Date\DateTime
      * @see \Yiisoft\Validator\Rule\Date\Time
      */
-    '{Property} must be no early than {limit}.' => '{Property} должно быть не ранее {limit}.',
-    '{Property} must be no late than {limit}.' => '{Property} должно быть не позднее {limit}.',
     '{Property} must be no earlier than {limit}.' => '{Property} должно быть не ранее {limit}.',
     '{Property} must be no later than {limit}.' => '{Property} должно быть не позднее {limit}.',
 

--- a/messages/uz/yii-validator.php
+++ b/messages/uz/yii-validator.php
@@ -159,8 +159,6 @@ return [
      * @see \Yiisoft\Validator\Rule\Date\DateTime
      * @see \Yiisoft\Validator\Rule\Date\Time
      */
-    '{Property} must be no early than {limit}.' => '{Property} {limit} dan oldin boʻlmasligi kerak.',
-    '{Property} must be no late than {limit}.' => '{Property} {limit} dan keyin boʻlmasligi kerak.',
     '{Property} must be no earlier than {limit}.' => '{Property} {limit} dan oldin boʻlmasligi kerak.',
     '{Property} must be no later than {limit}.' => '{Property} {limit} dan keyin boʻlmasligi kerak.',
 

--- a/src/Rule/Date/DateHandler.php
+++ b/src/Rule/Date/DateHandler.php
@@ -22,8 +22,8 @@ final class DateHandler extends BaseDateHandler
         ?string $messageFormat = null,
         ?int $messageDateType = IntlDateFormatter::SHORT,
         string $incorrectInputMessage = '{Property} must be a date.',
-        string $tooEarlyMessage = '{Property} must be no early than {limit}.',
-        string $tooLateMessage = '{Property} must be no late than {limit}.',
+        string $tooEarlyMessage = '{Property} must be no earlier than {limit}.',
+        string $tooLateMessage = '{Property} must be no later than {limit}.',
     ) {
         parent::__construct(
             $dateType,

--- a/src/Rule/Date/DateTimeHandler.php
+++ b/src/Rule/Date/DateTimeHandler.php
@@ -25,8 +25,8 @@ final class DateTimeHandler extends BaseDateHandler
         ?int $messageDateType = IntlDateFormatter::SHORT,
         ?int $messageTimeType = IntlDateFormatter::SHORT,
         string $incorrectInputMessage = '{Property} must be a date.',
-        string $tooEarlyMessage = '{Property} must be no early than {limit}.',
-        string $tooLateMessage = '{Property} must be no late than {limit}.',
+        string $tooEarlyMessage = '{Property} must be no earlier than {limit}.',
+        string $tooLateMessage = '{Property} must be no later than {limit}.',
     ) {
         parent::__construct(
             $dateType,

--- a/src/Rule/Date/TimeHandler.php
+++ b/src/Rule/Date/TimeHandler.php
@@ -22,8 +22,8 @@ final class TimeHandler extends BaseDateHandler
         ?string $messageFormat = null,
         ?int $messageTimeType = IntlDateFormatter::SHORT,
         string $incorrectInputMessage = '{Property} must be a time.',
-        string $tooEarlyMessage = '{Property} must be no early than {limit}.',
-        string $tooLateMessage = '{Property} must be no late than {limit}.',
+        string $tooEarlyMessage = '{Property} must be no earlier than {limit}.',
+        string $tooLateMessage = '{Property} must be no later than {limit}.',
     ) {
         parent::__construct(
             IntlDateFormatter::NONE,

--- a/tests/Rule/Date/DateTest.php
+++ b/tests/Rule/Date/DateTest.php
@@ -77,7 +77,7 @@ final class DateTest extends RuleTestCase
             'min' => [
                 '2024-03-29',
                 new Date(format: 'yyyy-MM-dd', min: '2025-01-01'),
-                ['' => ['Value must be no early than 1/1/25.']],
+                ['' => ['Value must be no earlier than 1/1/25.']],
             ],
             'min-custom-message' => [
                 ['a' => '2024-03-29'],
@@ -93,7 +93,7 @@ final class DateTest extends RuleTestCase
             'max' => [
                 '2024-03-29',
                 new Date(format: 'php:Y-m-d', max: '2024-01-01'),
-                ['' => ['Value must be no late than 1/1/24.']],
+                ['' => ['Value must be no later than 1/1/24.']],
             ],
             'max-custom-message' => [
                 ['a' => '2024-03-29'],
@@ -109,48 +109,48 @@ final class DateTest extends RuleTestCase
             'rule-and-handler-locales' => [
                 '2024-03-29',
                 new Date(format: 'php:Y-m-d', locale: 'ru', max: '2024-01-01'),
-                ['' => ['Value must be no late than 01.01.2024.']],
+                ['' => ['Value must be no later than 01.01.2024.']],
                 [DateHandler::class => new DateHandler(locale: 'en')],
             ],
             'handler-locale' => [
                 '2024-03-29',
                 new Date(format: 'php:Y-m-d', max: '2024-01-01'),
-                ['' => ['Value must be no late than 01.01.2024.']],
+                ['' => ['Value must be no later than 01.01.2024.']],
                 [DateHandler::class => new DateHandler(locale: 'ru')],
             ],
             'timestamp' => [
                 1711705158,
                 new Date(min: 1711705200),
-                ['' => ['Value must be no early than 3/29/24.']],
+                ['' => ['Value must be no earlier than 3/29/24.']],
             ],
             'without-message-date-type' => [
                 '29*03*2024',
                 new Date(format: 'php:d*m*Y', max: '11*11*2023', ),
-                ['' => ['Value must be no late than 11/11/23.']],
+                ['' => ['Value must be no later than 11/11/23.']],
                 [DateHandler::class => new DateHandler(messageDateType: null)],
             ],
             'rule-message-format' => [
                 '29*03*2024',
                 new Date(format: 'php:d*m*Y', max: '11*11*2023', messageFormat: 'php:d=m=Y'),
-                ['' => ['Value must be no late than 11=11=2023.']],
+                ['' => ['Value must be no later than 11=11=2023.']],
                 [DateHandler::class => new DateHandler(messageFormat: 'php:d_m_Y')],
             ],
             'handler-message-type' => [
                 'Mar 29, 2024',
                 new Date(max: 'Dec 11, 2019', dateType: IntlDateFormatter::MEDIUM),
-                ['' => ['Value must be no late than Wednesday, December 11, 2019.']],
+                ['' => ['Value must be no later than Wednesday, December 11, 2019.']],
                 [DateHandler::class => new DateHandler(messageDateType: IntlDateFormatter::FULL)],
             ],
             'rule-message-type-override-handler' => [
                 '3/29/2024',
                 new Date(max: '12/11/2019', messageDateType: IntlDateFormatter::SHORT),
-                ['' => ['Value must be no late than 12/11/19.']],
+                ['' => ['Value must be no later than 12/11/19.']],
                 [DateHandler::class => new DateHandler(messageDateType: IntlDateFormatter::FULL)],
             ],
             'rule-locale-override-handler' => [
                 '12.11.2002',
                 new Date(max: '10.11.2002', locale: 'ru'),
-                ['' => ['Value must be no late than 10.11.2002.']],
+                ['' => ['Value must be no later than 10.11.2002.']],
                 [DateHandler::class => new DateHandler(locale: 'en')],
             ],
         ];

--- a/tests/Rule/Date/DateTimeTest.php
+++ b/tests/Rule/Date/DateTimeTest.php
@@ -74,22 +74,22 @@ final class DateTimeTest extends RuleTestCase
             'min' => [
                 '2024-03-29, 12:35',
                 new DateTime(format: 'yyyy-MM-dd, HH:mm', min: '2025-01-01, 11:00'),
-                ['' => ['Value must be no early than 1/1/25, 11:00 AM.']],
+                ['' => ['Value must be no earlier than 1/1/25, 11:00 AM.']],
             ],
             'max' => [
                 '2024-03-29, 12:50',
                 new DateTime(format: 'php:Y-m-d, H:i', max: '2024-01-01, 00:00'),
-                ['' => ['Value must be no late than 1/1/24, 12:00 AM.']],
+                ['' => ['Value must be no later than 1/1/24, 12:00 AM.']],
             ],
             'timestamp' => [
                 1711705158,
                 new DateTime(format: 'php:d.m.Y, H:i:s', min: 1711705200),
-                ['' => ['Value must be no early than 3/29/24, 9:40 AM.']],
+                ['' => ['Value must be no earlier than 3/29/24, 9:40 AM.']],
             ],
             'without-message-date-and-time-type' => [
                 '29*03*2024*12*35',
                 new DateTime(format: 'php:d*m*Y*H*i', max: '11*11*2023*12*35'),
-                ['' => ['Value must be no late than 11/11/23, 12:35 PM.']],
+                ['' => ['Value must be no later than 11/11/23, 12:35 PM.']],
                 [DateTimeHandler::class => new DateTimeHandler(messageDateType: null, messageTimeType: null)],
             ],
         ];

--- a/tests/Rule/Date/TimeTest.php
+++ b/tests/Rule/Date/TimeTest.php
@@ -57,40 +57,40 @@ final class TimeTest extends RuleTestCase
             'min' => [
                 '15:30',
                 new Time(format: 'HH:mm', min: '15:40'),
-                ['' => ['Value must be no early than 3:40 PM.']],
+                ['' => ['Value must be no earlier than 3:40 PM.']],
             ],
             'max' => [
                 '15:30',
                 new Time(format: 'php:H:i', max: '12:00'),
-                ['' => ['Value must be no late than 12:00 PM.']],
+                ['' => ['Value must be no later than 12:00 PM.']],
             ],
             'timestamp' => [
                 1711705158,
                 new Time(format: 'php:d.m.Y, H:i:s', min: 1711705200),
-                ['' => ['Value must be no early than 9:40 AM.']],
+                ['' => ['Value must be no earlier than 9:40 AM.']],
             ],
             'without-message-time-type' => [
                 '13*30',
                 new Time(format: 'php:H*i', max: '11*30'),
-                ['' => ['Value must be no late than 11:30 AM.']],
+                ['' => ['Value must be no later than 11:30 AM.']],
                 [TimeHandler::class => new TimeHandler(messageTimeType: null)],
             ],
             'rule-message-format' => [
                 '13*30',
                 new Time(format: 'php:H*i', max: '11*30', messageFormat: 'php:H-i'),
-                ['' => ['Value must be no late than 11-30.']],
+                ['' => ['Value must be no later than 11-30.']],
                 [TimeHandler::class => new TimeHandler(messageFormat: 'php:H_i')],
             ],
             'handler-message-type' => [
                 '13*30',
                 new Time(format: 'php:H*i', max: '11*30', timeType: IntlDateFormatter::SHORT),
-                ['' => ['Value must be no late than 11:30:00 AM Coordinated Universal Time.']],
+                ['' => ['Value must be no later than 11:30:00 AM Coordinated Universal Time.']],
                 [TimeHandler::class => new TimeHandler(messageTimeType: IntlDateFormatter::FULL)],
             ],
             'rule-message-type-override-handler' => [
                 '13*30',
                 new Time(format: 'php:H*i', max: '11*30', messageTimeType: IntlDateFormatter::SHORT),
-                ['' => ['Value must be no late than 11:30 AM.']],
+                ['' => ['Value must be no later than 11:30 AM.']],
                 [TimeHandler::class => new TimeHandler(messageTimeType: IntlDateFormatter::FULL)],
             ],
         ];


### PR DESCRIPTION
Fixes the grammatically incorrect default date/time comparison messages introduced in 2779afc2a58d3610ca3f230398f39d3b3424f225 by changing "no early than" to "no earlier than" and "no late than" to "no later than". Also updates matching tests and translation source keys.

Checks:
- vendor/bin/phpunit --testdox tests/Rule/Date
- vendor/bin/phpunit --testdox tests/MessagesTest.php tests/ConfigTest.php
- git diff --check

Note: a full vendor/bin/phpunit --testdox run currently fails in an unrelated EmailTest case: Ivan Petrov <ipetrov@gmail.com> is rejected as invalid.