### PR TITLE
Remove BC dev dependency input

### DIFF
--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -30,5 +30,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
-      install-development-dependencies: true
+        ['8.3']

--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<roave-bc-check
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/roave/backward-compatibility-check/Resources/schema.xsd">
+    <baseline>
+        <ignored-regex>#^\[BC\] SKIPPED: Roave\\BetterReflection\\Reflection\\ReflectionClass "Yiisoft\\Yii\\Debug\\#</ignored-regex>
+        <ignored-regex>#^\[BC\] CHANGED: Default parameter value for parameter \$too(Early|Late)Message of Yiisoft\\Validator\\Rule\\Date\\(Date|DateTime|Time)Handler\#__construct\(\) changed from #</ignored-regex>
+    </baseline>
+</roave-bc-check>


### PR DESCRIPTION
## Summary
- remove the install-development-dependencies input from the reusable BC workflow call
- run the BC workflow on PHP 8.3 so Roave's XML baseline support is available
- add Roave BC baseline ignores for dev-only Yii Debug classes and existing date/time message default changes

## Related
- yiisoft/actions#129 removes the input from the reusable workflow

## Verification
- vendor/bin/roave-backward-compatibility-check passed locally with: No backwards-incompatible changes detected