### PR TITLE
Fix docs workflow pull request permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Update docs translation
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'docs/po/**'
       - 'docs/pot/**'
@@ -13,23 +13,49 @@ on:
     paths:
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
-  update-docs:
-    name: Update docs
+  check-docs:
+    name: Check docs
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.YIISOFT_GITHUB_TOKEN || github.token }}
-          ref: ${{ github.head_ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          persist-credentials: false
 
       - name: Prepare po4a configuration
         run: docs/prepare-config.sh
 
       - name: Use po4a
-        uses: vjik/docker-run@v1
+        uses: vjik/docker-run@623c9adf6ee99fc8f9fa4e3b0b6b0c25859b69ee # v1
+        with:
+          image: ghcr.io/yiisoft-contrib/po4a:0.74
+          volumes: ${{ github.workspace }}:/src
+          workdir: /src/docs
+          command: po4a po4a.conf && po4a po4a.conf
+
+  update-docs:
+    name: Update docs
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.YIISOFT_GITHUB_TOKEN || github.token }}
+          persist-credentials: false
+
+      - name: Prepare po4a configuration
+        run: docs/prepare-config.sh
+
+      - name: Use po4a
+        uses: vjik/docker-run@623c9adf6ee99fc8f9fa4e3b0b6b0c25859b69ee # v1
         with:
           image: ghcr.io/yiisoft-contrib/po4a:0.74
           volumes: ${{ github.workspace }}:/src
@@ -37,7 +63,15 @@ jobs:
           command: po4a po4a.conf && po4a po4a.conf
 
       - name: Commit changed files
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Update docs translation
-          file_pattern: 'docs'
+        env:
+          GH_TOKEN: ${{ secrets.YIISOFT_GITHUB_TOKEN || github.token }}
+        run: |
+          if [ -z "$(git status --porcelain -- docs)" ]; then
+            exit 0
+          fi
+
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add docs
+          git commit -m "Update docs translation"
+          git -c "credential.helper=!f() { echo username=x-access-token; echo password=\$GH_TOKEN; }; f" push origin HEAD:master


### PR DESCRIPTION
## Summary
- replace the privileged docs translation `pull_request_target` path with an unprivileged `pull_request` check
- keep the auto-commit flow restricted to trusted pushes to `master`
- set explicit permissions, disable checkout credential persistence, and pin third-party actions by SHA
- replace the auto-commit action with a small trusted push-only git step

## Validation
- `actionlint .github/workflows/docs.yml`
- `zizmor --format plain .github/workflows/docs.yml`