### PR TITLE
Remove Codecov failure override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
         ['ubuntu-latest', 'windows-latest']
       php: >-
         ['8.1', '8.2', '8.3', '8.4', '8.5']
-      codecovFailCiIfError: false
   phpunit-without-intl:
     uses: yiisoft/actions/.github/workflows/phpunit.yml@master
     secrets:
@@ -50,4 +49,3 @@ jobs:
         ['ubuntu-latest', 'windows-latest']
       php: >-
         ['8.1', '8.2', '8.3', '8.4', '8.5']
-      codecovFailCiIfError: false


### PR DESCRIPTION
Removes the explicit codecovFailCiIfError override from the PHPUnit workflow so the shared workflow default is used. Validation: git diff --check.